### PR TITLE
adds tags and criteria

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:
+  - bundle exec standardrb
   - bundle exec rspec
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: ruby
 rvm:
   - 2.5.5
   - 2.6.3
-  - 2.7.0-preview
   - jruby-9.2.7.0
 before_install: gem install bundler
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ env:
 sudo: false
 language: ruby
 rvm:
+  - 2.3.8
+  - 2.4.6
   - 2.5.5
   - 2.6.3
-  - jruby-9.2.7.0
 before_install: gem install bundler
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/lib/shifty/dsl.rb
+++ b/lib/shifty/dsl.rb
@@ -30,7 +30,7 @@ module Shifty
     def side_worker(mode = :normal, &block)
       ensure_regular_arity(block)
 
-      Worker.new do |value|
+      Worker.new(tags: [:side_effect]) do |value|
         value.tap do |v|
           used_value = mode == :hardened ?
             Marshal.load(Marshal.dump(v)) : v

--- a/lib/shifty/roster.rb
+++ b/lib/shifty/roster.rb
@@ -1,4 +1,4 @@
-require 'forwardable'
+require "forwardable"
 
 module Shifty
   class Roster

--- a/spec/shifty/dsl_spec.rb
+++ b/spec/shifty/dsl_spec.rb
@@ -157,6 +157,7 @@ module Shifty
           Then { worker.shift == [:foo, :boo] }
           And  { worker.shift == [:bar, :boo] }
           And  { worker.shift.nil? }
+          Then { expect(worker.tags).to include(:side_effect) }
         end
 
         context ":hardened" do

--- a/spec/shifty/gang_spec.rb
+++ b/spec/shifty/gang_spec.rb
@@ -6,14 +6,15 @@ module Shifty
     Given(:plusser) { relay_worker { |v| v + "+" } }
     Given(:tilda_er) { relay_worker { |v| v + "~" } }
 
-    When(:gang) { described_class[ *workers ] }
+    When(:gang) { described_class[*workers] }
 
     context "covers Worker API" do
       Then do
         expect(subject).to respond_to(
           :ready_to_work?, :shift,
           :supply, :supply=,
-          :supplies, :"|")
+          :supplies, :"|"
+        )
       end
     end
 
@@ -56,7 +57,6 @@ module Shifty
       context "gets gang as source" do
         Then { tilda_er.shift == "a+~" }
       end
-
     end
 
     context "#append" do

--- a/spec/shifty/worker_spec.rb
+++ b/spec/shifty/worker_spec.rb
@@ -162,25 +162,25 @@ module Shifty
     end
 
     describe ":criteria" do
-      Given(:source_worker) { Worker.new { :foo }  }
+      Given(:source_worker) { Worker.new { :foo } }
       Given(:worker) { Worker.new(criteria: criteria) { |v| "#{v}_bar".to_sym } }
 
       When(:pipeline) { source_worker | worker }
 
       context "when criteria returns true" do
-        Given(:criteria) { Proc.new { true } }
+        Given(:criteria) { proc { true } }
 
         Then { pipeline.shift == :foo_bar }
       end
 
       context "when criteria returns false" do
-        Given(:criteria) { Proc.new { false } }
+        Given(:criteria) { proc { false } }
 
         Then { pipeline.shift == :foo }
       end
 
       context "criteria can interrogate worker" do
-        Given(:criteria) { Proc.new { |w| w.has_tag? :uno } }
+        Given(:criteria) { proc { |w| w.has_tag? :uno } }
 
         context "passing criteria" do
           Given { worker.tags = :uno }
@@ -196,8 +196,8 @@ module Shifty
       end
 
       context "multiple criteria" do
-        Given(:criteria1) { Proc.new { |w| w.has_tag? :uno } }
-        Given(:criteria2) { Proc.new { |w| w.has_tag? :dos } }
+        Given(:criteria1) { proc { |w| w.has_tag? :uno } }
+        Given(:criteria2) { proc { |w| w.has_tag? :dos } }
         Given(:criteria) { [criteria1, criteria2] }
 
         context "passing all criteria" do


### PR DESCRIPTION
It is interesting to notice _monad-like_ patterns cropping up: the desire for hot-swappable criteria and/or criteria from various provenances (e.g. worker-imposed, gang-imposed, app or globally imposed) ...this leads to a desire for a wrapping object which could be given to a worker, but whose operation could be redefined from elsewhere at a later point in time.