### PR TITLE
Redesigned Gang and Roster

### DIFF
--- a/lib/shifty/gang.rb
+++ b/lib/shifty/gang.rb
@@ -2,43 +2,40 @@ require "shifty/roster"
 
 module Shifty
   class Gang
-    attr_accessor :workers
+    attr_accessor :roster
 
     def initialize(workers = [])
-      link(workers + [])
-    end
-
-    def roster
-      workers
+      @roster = Roster.new(workers)
     end
 
     def shift
-      workers.last.shift
+      roster.last.shift
     end
 
     def ready_to_work?
-      workers.first.ready_to_work?
+      roster.first.ready_to_work?
     end
 
     def supply
-      workers.first.supply
+      roster.first.supply
     end
 
     def supply=(source_queue)
-      workers.first.supply = source_queue
+      roster.first.supply = source_queue
     end
 
-    def supplies(subscribing_party)
-      subscribing_party.supply = self
+    def supplies(subscribing_worker)
+      subscribing_worker.supply = self
     end
     alias | supplies
 
-    private
+    def append(worker)
+      roster << worker
+    end
 
-    def link(workers)
-      @workers = [workers.shift]
-      while (worker = workers.shift)
-        Roster[self] << worker
+    class << self
+      def [](*workers)
+        new workers
       end
     end
   end

--- a/lib/shifty/roster.rb
+++ b/lib/shifty/roster.rb
@@ -1,33 +1,30 @@
+require 'forwardable'
+
 module Shifty
-  module Roster
-    class << self
-      def [](gang)
-        RosterizedGang.new(gang)
+  class Roster
+    extend Forwardable
+
+    attr_reader :workers
+
+    def initialize(workers = [])
+      @workers = []
+      workers.each do |worker|
+        push worker
       end
     end
-  end
 
-  class RosterizedGang
-    attr_reader :gang
-
-    def initialize(gang)
-      @gang = gang
-    end
-
-    def workers
-      gang.workers
-    end
+    def_delegators :workers, :first, :last
 
     def push(worker)
       if worker
-        worker.supply = workers.last
+        worker.supply = workers.last unless workers.empty?
         workers << worker
       end
     end
     alias << push
 
     def pop
-      gang.workers.pop.tap do |popped|
+      workers.pop.tap do |popped|
         popped.supply = nil
       end
     end

--- a/spec/shifty/gang_spec.rb
+++ b/spec/shifty/gang_spec.rb
@@ -6,11 +6,12 @@ module Shifty
     Given(:plusser) { relay_worker { |v| v + "+" } }
     Given(:tilda_er) { relay_worker { |v| v + "~" } }
 
-    When(:gang) { described_class.new workers }
+    When(:gang) { described_class[ *workers ] }
 
     context "covers Worker API" do
       Then do
-        expect(subject).to respond_to(:ready_to_work?, :shift,
+        expect(subject).to respond_to(
+          :ready_to_work?, :shift,
           :supply, :supply=,
           :supplies, :"|")
       end
@@ -56,19 +57,18 @@ module Shifty
         Then { tilda_er.shift == "a+~" }
       end
 
-      context "still works even if rearranging workers" do
-        Given(:minuser) { relay_worker { |v| v + "-" } }
-
-        When { Roster[gang].push minuser }
-
-        Then { tilda_er.shift == "a+-~" }
-      end
     end
 
-    describe "#roster" do
-      Given(:workers) { [source, plusser, tilda_er] }
+    context "#append" do
+      Given(:workers) { [source, plusser] }
+      Given(:minuser) { relay_worker { |v| v + "-" } }
 
-      Then { gang.roster == workers }
+      When { gang | tilda_er }
+      When { gang.append minuser }
+
+      context "adds a worker to the end of the gang's roster" do
+        Then { tilda_er.shift == "a+-~" }
+      end
     end
 
     context "normal usage" do


### PR DESCRIPTION
Cleaned up the abstractions of `Gang` and `Roster` so that `Roster` knows nothing about `Gang`, and really just has the responsibility to supply meaningful stack operations on a list of workers.

`Gang`, meanwhile, has the responsibility to wrap `Roster` and give it Worker-like behavior.

TODO: Currently `Gang` is initialized with an array of workers, but it might be nice to be able to build the `Roster` you want, and then initialize the `Gang` with that `Roster`.