### PR TITLE
Adds tags and criteria for gangs

### DIFF
--- a/lib/shifty/gang.rb
+++ b/lib/shifty/gang.rb
@@ -1,21 +1,16 @@
 require "shifty/roster"
+require "shifty/taggable"
 
 module Shifty
   class Gang
     attr_reader :roster, :tags
 
+    include Taggable
+
     def initialize(workers = [], p = {})
       @roster = Roster.new(workers)
-      @criteria = [p[:criteria] || []].flatten
-      self.tags = p[:tags] || []
-    end
-
-    def tags=(tag_arg)
-      @tags = [tag_arg].flatten
-    end
-
-    def has_tag?(tag)
-      tags.include? tag
+      self.criteria = p[:criteria]
+      self.tags     = p[:tags]
     end
 
     def shift
@@ -24,12 +19,6 @@ module Shifty
       else
         roster.first.supply.shift
       end
-    end
-
-    def criteria_passes?
-      return true if @criteria.empty?
-
-      @criteria.all? { |c| c.call(self) }
     end
 
     def ready_to_work?

--- a/lib/shifty/taggable.rb
+++ b/lib/shifty/taggable.rb
@@ -1,0 +1,21 @@
+module Shifty
+  module Taggable
+    def tags=(tag_arg)
+      @tags = [tag_arg].flatten.compact
+    end
+
+    def criteria=(criteria_arg)
+      @criteria = [criteria_arg].flatten.compact
+    end
+
+    def has_tag?(tag)
+      @tags.include? tag
+    end
+
+    def criteria_passes?
+      return true if @criteria.empty?
+
+      @criteria.all? { |c| c.call(self) }
+    end
+  end
+end

--- a/lib/shifty/worker.rb
+++ b/lib/shifty/worker.rb
@@ -1,15 +1,18 @@
 require "ostruct"
+require "shifty/taggable"
 
 module Shifty
   class Worker
     attr_reader :supply, :tags
 
+    include Shifty::Taggable
+
     def initialize(p = {}, &block)
-      @supply   = p[:supply]
-      @task     = block || p[:task]
-      @context  = p[:context] || OpenStruct.new
-      @criteria = [p[:criteria] || []].flatten
-      self.tags = p[:tags] || []
+      @supply       = p[:supply]
+      @task         = block || p[:task]
+      @context      = p[:context] || OpenStruct.new
+      self.criteria = p[:criteria]
+      self.tags     = p[:tags]
     end
 
     def shift
@@ -34,14 +37,6 @@ module Shifty
 
     def suppliable?
       @task && @task.arity > 0
-    end
-
-    def tags=(tag_arg)
-      @tags = [tag_arg].flatten
-    end
-
-    def has_tag?(tag)
-      tags.include? tag
     end
 
     private
@@ -81,12 +76,6 @@ module Shifty
 
     def task_method_accepts_a_value?
       method(:task).arity > 0
-    end
-
-    def criteria_passes?
-      return true if @criteria.empty?
-
-      @criteria.all? { |c| c.call(self) }
     end
   end
 

--- a/lib/shifty/worker.rb
+++ b/lib/shifty/worker.rb
@@ -21,9 +21,9 @@ module Shifty
       @task && (supply || !task_accepts_a_value?)
     end
 
-    def supplies(subscribing_party)
-      subscribing_party.supply = self
-      subscribing_party
+    def supplies(subscribing_worker)
+      subscribing_worker.supply = self
+      subscribing_worker
     end
     alias_method :|, :supplies
 

--- a/spec/shifty/gang_spec.rb
+++ b/spec/shifty/gang_spec.rb
@@ -3,8 +3,8 @@ module Shifty
     include DSL
 
     Given(:source) { source_worker((:a..:z).map(&:to_s)) }
-    Given(:plusser) { relay_worker { |v| v + "+" } }
-    Given(:tilda_er) { relay_worker { |v| v + "~" } }
+    Given(:b_appender) { relay_worker { |v| v + "_b" } }
+    Given(:c_appender) { relay_worker { |v| v + "_c" } }
 
     When(:gang) { described_class[*workers] }
 
@@ -20,27 +20,27 @@ module Shifty
 
     describe "#ready_to_work?" do
       context "with no source" do
-        Given(:workers) { [plusser, tilda_er] }
+        Given(:workers) { [b_appender, c_appender] }
 
         Then { expect(gang).to_not be_ready_to_work }
       end
 
       context "with an internal source" do
-        Given(:workers) { [source, plusser, tilda_er] }
+        Given(:workers) { [source, b_appender, c_appender] }
 
         Then { expect(gang).to be_ready_to_work }
       end
 
       context "with external source" do
         context "supplied to the first worker" do
-          Given { source | plusser }
-          Given(:workers) { [plusser, tilda_er] }
+          Given { source | b_appender }
+          Given(:workers) { [b_appender, c_appender] }
 
           Then { expect(gang).to be_ready_to_work }
         end
 
         context "supplied to the gang" do
-          Given(:workers) { [plusser, tilda_er] }
+          Given(:workers) { [b_appender, c_appender] }
 
           When { gang.supply = source }
 
@@ -50,31 +50,92 @@ module Shifty
     end
 
     describe "#| (a.k.a. #supplies)" do
-      Given(:workers) { [source, plusser] }
+      Given(:workers) { [source, b_appender] }
 
-      When { gang | tilda_er }
+      When { gang | c_appender }
 
       context "gets gang as source" do
-        Then { tilda_er.shift == "a+~" }
+        Then { expect(c_appender.shift).to eq("a_b_c") }
       end
     end
 
     context "#append" do
-      Given(:workers) { [source, plusser] }
-      Given(:minuser) { relay_worker { |v| v + "-" } }
+      Given(:workers) { [source, b_appender] }
+      Given(:d_appender) { relay_worker { |v| v + "_d" } }
 
-      When { gang | tilda_er }
-      When { gang.append minuser }
+      When { gang | c_appender }
+      When { gang.append d_appender }
 
       context "adds a worker to the end of the gang's roster" do
-        Then { tilda_er.shift == "a+-~" }
+        Then { expect(c_appender.shift).to eq("a_b_d_c") }
       end
     end
 
     context "normal usage" do
-      Given(:workers) { [source, plusser, tilda_er] }
+      Given(:workers) { [source, b_appender, c_appender] }
 
-      Then { gang.shift == "a+~" }
+      Then { expect(gang.shift).to eq("a_b_c") }
+    end
+
+    describe ":tags" do
+      Given(:workers) { [source, b_appender, c_appender] }
+
+      context "no tags" do
+        Then { expect(gang.tags).to eq([]) }
+      end
+
+      context "initialization" do
+        When(:gang) { described_class.new(workers, tags: tag_arg) }
+
+        context "a single tag" do
+          Given(:tag_arg) { :foo }
+          Then { expect(gang.tags).to eq([:foo]) }
+        end
+
+        context "multiple tags" do
+          Given(:tag_arg) { [:foo, :bar] }
+          Then { expect(gang.tags).to eq([:foo, :bar]) }
+        end
+      end
+
+      context "by assignment" do
+        When { gang.tags = tag_arg }
+
+        context "a single tag" do
+          Given(:tag_arg) { :foo }
+          Then { expect(gang.tags).to eq([:foo]) }
+        end
+
+        context "multiple tags" do
+          Given(:tag_arg) { [:foo, :bar] }
+          Then { expect(gang.tags).to eq([:foo, :bar]) }
+        end
+      end
+
+      describe "#has_tag?" do
+        Given(:gang) { described_class.new workers }
+        When { gang.tags = [:foo] }
+
+        Then { expect(gang).to have_tag(:foo) }
+        Then { expect(gang).to_not have_tag(:bar) }
+      end
+    end
+
+    describe ":criteria" do
+      Given(:workers) { [b_appender, c_appender] }
+      Given(:d_appender) { relay_worker { |v| v + "_d" } }
+      Given(:gang) { described_class.new(workers, criteria: criteria) }
+      When(:pipeline) { source | gang | d_appender }
+
+      context "when criteria returns truthy" do
+        Given(:criteria) { proc { true } }
+        Then { expect(pipeline.shift).to eq("a_b_c_d") }
+      end
+
+      context "when criteria returns falsy" do
+        Given(:criteria) { proc { false } }
+        Then { expect(pipeline.shift).to eq("a_d") }
+      end
     end
   end
 end


### PR DESCRIPTION
Extends the workers' tags and criteria API to `Gang`s.  Ideally a `Gang` should cover the `Worker`'s API so that it can be used interchangeably with `Worker`s.

- [x] Refactor tags/criteria into an includable module
- [ ] Add README documentations for tags and criteria