### PR TITLE
Handoff immutability policies, Phase 1: the policy mechanism

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,10 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: tests
 
 on:
@@ -18,15 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.2', '3.3', '3.4']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/docs/planning/artifacts/.discovery-notes.md
+++ b/docs/planning/artifacts/.discovery-notes.md
@@ -1,0 +1,40 @@
+# Discovery Notes — Handoff Immutability Policies implementation planning
+
+## Tech stack
+- Ruby gem "shifty", current version 0.5.0 (`lib/shifty/version.rb`). No `required_ruby_version` in gemspec yet (decision: add `>= 3.2`).
+- Local Ruby: 4.0.5 (arm64-darwin). Runtime deps: none (stdlib only; `ostruct`, `forwardable`, `fiber`).
+- Tests: RSpec 3.x + rspec-given (Given/When/Then style), simplecov; specs in `spec/shifty/{worker,gang,roster,dsl}_spec.rb`; `.rspec_status` persistence; monkey-patching disabled.
+- Lint: standardrb (`.standard.yml` ignores Layout/ExtraSpacing). Rakefile standard bundler/gem_tasks (build via `rake build` / `gem build`).
+- CI: `.github/` exists (workflows not yet examined by specialists — check if Ruby matrix needs updating for the 3.2 floor).
+
+## Source spec
+- `docs/planning/handoff-immutability-policies.md` — full design doc, 13 sections + appendix. Treat as ground truth for WHAT. No plan-a-feature artifacts (no decision-log/team-findings/feature-technical-notes).
+
+## Code touch points
+- `lib/shifty/worker.rb` — Worker: `initialize(p = {}, &block)` takes `:supply, :task, :context, :criteria, :tags`. Fiber-based `workflow` loop at line ~62: `Fiber.yield @task.call(value, supply, @context)` — THE handoff site for task output; `value = supply&.shift` is the intake site. Has `supply=` writer (no `task=` writer despite spec §5.4 mentioning one — only `@task ||= default_task` lazily). Extensive concurrency-model comment block (lines 90–130) added by PR #26; forward-references this plan and must be updated from "planned" to shipped.
+- `lib/shifty/dsl.rb` — DSL worker constructors: `source_worker`, `relay_worker`, `side_worker` (has `mode: :hardened` → `Marshal.load(Marshal.dump(v))` at lines 40–41 — the feature to deprecate/subsume), `filter_worker`, `batch_worker` (BatchContext < OpenStruct), `splitter_worker` (mutates `parts` array internally via `parts.shift` — internal, not the handed-off value), `trailing_worker` (accumulates `trail` array in closure AND hands off `trail` itself — a live aliasing case under `:frozen`; hands off the same array it keeps mutating via unshift/pop!). `handoff` = `Fiber.yield`.
+- `lib/shifty/gang.rb` — Gang wraps Roster; `initialize(workers = [], p = {})`; `shift` delegates to `roster.last.shift`; `Gang[*workers]` constructor; `|`/`supplies` composition same as Worker.
+- `lib/shifty/roster.rb` — push/pop/shift/unshift rewires `supply` — mutation of topology, relevant to §5.4 `#freeze!`.
+- `lib/shifty/taggable.rb` — tags/criteria mixin shared by Worker and Gang.
+- `lib/shifty.rb` — requires all; no `Shifty.configure` exists yet (global config is new).
+- No `Shifty::Testing`, no RSpec helpers shipped by the gem today.
+
+## Important behavioral details for policy implementation
+- Composition (`|`) links workers by setting `supply`; there is NO chain/pipeline object for plain worker chains — a "pipeline" is just the last worker; Gang is the only reifying container. `.with_policy` on a composed chain must therefore live on Worker (and Gang) and propagate upstream via the supply chain.
+- `filter_worker` and `batch_worker` tasks call `supply.shift` themselves mid-task — values obtained that way ALSO cross a boundary (policy must apply at intake, not just at task-output yield, or these secondary intakes leak).
+- `splitter_worker` and `source_worker` use `handoff` (Fiber.yield) directly from inside the task — multiple handoffs per task call; policy application at the single `Fiber.yield @task.call(...)` site won't see these. Handoff site analysis is a core design task.
+- `trailing_worker` hands off its live closure array — will break under `:frozen` default; the spec (§7.3) says this is exactly the bug class the policy should catch; the shipped worker itself must be fixed (hand off a snapshot).
+- Worker's nil sentinel: nil marks end-of-stream; `relay_worker`/`side_worker` guard `value &&`. nil is already frozen/shareable — no policy cost.
+- `@context` (OpenStruct) is closure-ish per-worker state passed to tasks — NOT a handoff; stays mutable per spec §12.
+
+## ADRs / coding standards
+- None found (no docs/adr, no coding standards docs). Style = standardrb defaults. Doc precedent: `docs/use_cases.md`, `docs/shifty/worker.md`, README.md (rewritten by PR #26 with "Concurrency Model" section).
+
+## Recent activity (90 days)
+- 1dc5433 planning doc (this feature); 847ee06/d14823a PR #26 concurrency docs (README.md, docs/use_cases.md, lib/shifty/worker.rb comments); 43d5948 concurrency analysis; 5e8ca16 arity fix in dsl.rb.
+
+## Gaps searched and not found
+- No CLAUDE.md/AGENTS.md in repo. No CI examination yet. No benchmark tooling (no benchmark-ips in Gemfile). No existing implementation-plan format precedent in this repo.
+
+## User-committed decisions (from Joel, this session)
+1. Version 0.6.0, all four spec phases ship in it. 2. required_ruby_version >= 3.2. 3. API: worker `policy:` kwarg; chainable `.with_policy(:p)` on Worker AND Gang; `policy:` kwarg on Gang; `Shifty.configure { |c| c.default_policy = ... }`; built-in default `:frozen`; precedence worker > pipeline > global. 4. One PR per phase. 5. Wiki content drafted under `docs/wiki/`, pushed to GitHub wiki after merge. 6. `:hardened` deprecated → mapped to `:isolated` with warning. 7. §8.3 option (b) — no shareable? fast path initially; worker declarations authoritative, pipeline policy default-only. 8. Joel publishes the gem himself (2FA); plan ends at built gem + release prep.

--- a/docs/planning/artifacts/.round1-specialist-outputs.md
+++ b/docs/planning/artifacts/.round1-specialist-outputs.md
@@ -1,0 +1,196 @@
+# Round 1 verbatim specialist outputs (reference for synthesis & implementation)
+
+## software-architect (A1–A7)
+
+**A1: Apply policy at INGRESS (the consuming worker's pull), via a single intake seam plus a thin policy-applying supply proxy for in-task shifts.**
+Sites today: worker.rb:64 `value = supply&.shift`; worker.rb:66 `Fiber.yield @task.call(...)`; in-task `supply.shift` in filter_worker/batch_worker/trailing_worker (dsl.rb:56,86,122); direct `handoff`/Fiber.yield in source_worker/splitter_worker (dsl.rb:17,105,133). Make policy a property of *how a worker receives its value* (§6.2 names the receiving worker). Producer-side direct handoffs need nothing — their outputs are frozen at the downstream consumer's intake. Sketch:
+
+```ruby
+# worker.rb
+def workflow
+  @machine ||= Fiber.new do
+    loop do
+      value = intake(@supply&.shift)          # primary intake seam
+      if criteria_passes?
+        Fiber.yield perform_task(value, policy_supply)
+      else
+        Fiber.yield value                       # already policy-applied
+      end
+    end
+  end
+end
+
+def intake(value)
+  effective_policy.apply(value, worker: self)   # freeze / copy / passthrough
+end
+
+def perform_task(value, supply_proxy)
+  @task.call(value, supply_proxy, @context)
+rescue FrozenError => e
+  raise PolicyViolation.new(worker: self, policy: effective_policy,
+                            receiver: e.receiver, value: value, cause: e)
+end
+
+def policy_supply
+  @policy_supply ||= PolicySupply.new(@supply, self)  # #shift => intake(supply.shift)
+end
+```
+
+`PolicySupply` proxy replaces the raw `supply` as the task's 2nd arg, so filter/batch/trailing's in-task `supply.shift` transparently applies the same policy with zero task-body changes (three concrete uses today — Rule of Three met). §7.3 aliasing still caught: make_shareable freezes the actual object in place, so the producer's later mutation raises at the producer. Rejected simpler version: freeze at the single egress site — misses in-task shifts and makes producer policy govern the boundary, contradicting §5.2.
+
+**A2: `Shifty::Policy` module of three frozen singleton lambdas behind `resolve(name)`; precedence resolution stays inline on Worker.**
+
+```ruby
+# lib/shifty/policy.rb
+module Shifty
+  module Policy
+    Frozen   = ->(value, worker:) { Ractor.make_shareable(value) }   # wrapped for UnshareableValue
+    Isolated = ->(value, worker:) { make_shareable_copy_or_marshal(value) }
+    Shared   = ->(value, worker:) { value }
+
+    TABLE = {frozen: Frozen, isolated: Isolated, shared: Shared}.freeze
+    ALIASES = {hardened: :isolated}.freeze
+    def self.resolve(name)
+      name = canonical(name)   # applies ALIASES + :hardened deprecation warn
+      TABLE.fetch(name) { raise ArgumentError, "unknown policy #{name.inspect}" }
+    end
+  end
+end
+```
+
+Not a class hierarchy, not a mixin (policy is a collaborator, not worker state — contrast Taggable). Each apply wraps make_shareable/Marshal failures as UnshareableValue. Precedence inline:
+```ruby
+def effective_policy
+  @effective_policy ||= Policy.resolve(@policy || @pipeline_policy || Shifty.config.default_policy)
+end
+```
+
+**A3: Two attributes — `@policy` (explicit contract) and `@pipeline_policy` (default) — `.with_policy` walks the supply chain; Gang fans out to roster.**
+
+```ruby
+# worker.rb
+attr_accessor :pipeline_policy
+def initialize(p = {}, &block)
+  @policy = p[:policy]      # explicit contract, may be nil
+  @name   = p[:name]        # §5.5 diagnostics
+end
+
+def with_policy(name)
+  Policy.resolve(name)                       # validate eagerly
+  node = self
+  while node.respond_to?(:pipeline_policy=)  # walks Workers and Gangs
+    node.pipeline_policy = name
+    node = node.supply
+  end
+  self
+end
+```
+```ruby
+# gang.rb
+def initialize(workers = [], p = {})
+  self.pipeline_policy = p[:policy] if p[:policy]
+end
+def pipeline_policy=(name)
+  roster.workers.each { |w| w.pipeline_policy = name }
+end
+def with_policy(name)
+  self.pipeline_policy = name
+  self
+end
+```
+Gang#supply returns roster.first.supply, so the walk steps past a gang to its upstream after the gang fans out internally. Rejected: single @policy + declared? flag (forces branching); downstream-walk storage (workers don't know their consumer).
+
+**A4: Consolidate errors into lib/shifty/errors.rb under Shifty::Error base.**
+```ruby
+module Shifty
+  class Error < StandardError; end
+  class WorkerError < Error; end                # reparented, source-compatible
+  class WorkerInitializationError < Error; end  # moved from dsl.rb
+  class PolicyError < Error; end
+  class PolicyViolation  < PolicyError; end     # attrs: worker, policy, receiver, value, cause (§6.2)
+  class UnshareableValue < PolicyError; end     # attrs: worker, policy, value
+end
+```
+(PolicyConflict was proposed as class-only; user decision R2: dropped entirely.)
+
+**A5: Global config.**
+```ruby
+# lib/shifty/configuration.rb
+module Shifty
+  class Configuration
+    attr_accessor :default_policy
+    def initialize; @default_policy = :frozen; end
+  end
+  class << self
+    def config; @config ||= Configuration.new; end
+    def configure; yield config; end
+    def reset_configuration!; @config = Configuration.new; end  # test hook
+  end
+end
+```
+Effective policy memoized at first shift (topology assembled by then); per-handoff re-resolution unnecessary. Thread-safety documentation-only, consistent with worker.rb:117–130.
+
+**A6: `shifty/testing` (pure Ruby) and `shifty/rspec` (opt-in) as separate requires; neither loaded by `require "shifty"`.**
+- lib/shifty/testing.rb: `Shifty::Testing.run(worker, inputs:, policy: nil)` — feeds inputs through the framework so declared/effective policy is exercised (§9.2/§9.3); `Shifty::Testing.mutates_input?(worker, input)` — §6.4 detector: deep-copy, run, compare.
+- lib/shifty/rspec.rb: `RSpec.shared_examples "a policy-safe worker"` (ceiling test §9.4) and `mutate_input` matcher built on the detector.
+
+**A7: Fix trailing_worker to hand off `trail.dup`; route side_worker :hardened through the deprecation shim (Policy.canonical).** DSL constructors already splat options into Worker.new, so policy:/name: pass through for free; only trailing_worker and source_worker build options by hand and need explicit threading. Rejected: internally declaring trailing_worker `policy: :shared` — masks the aliasing instead of fixing it.
+
+**Deferred (YAGNI) per architect:** PolicyConflict validation (now dropped entirely per user); §8.3 shareable? fast path (reopen: benchmarks show copy cost material); Shifty::Value mixin (§11.5 — spec itself says stay unopinionated).
+**New files:** Phase 1: lib/shifty/errors.rb, lib/shifty/policy.rb, lib/shifty/configuration.rb. Phase 2: lib/shifty/testing.rb, lib/shifty/rspec.rb.
+
+## concurrency-analyst (F1–F22, empirical on Ruby 4.0.5 — re-verify on 3.2 CI)
+
+- F1/F2: policy is the *receiving* worker's, applied at intake. Exactly four `supply.shift` read sites (worker.rb:64; dsl.rb:55 filter; dsl.rb:86 batch; dsl.rb:122 trailing) — the minimal enforcement set; no value crosses twice, so no double-copy waste under :isolated.
+- F3: do NOT instrument `handoff`/Fiber.yield — `handoff` is a free DSL function with no access to the executing worker; every internal yield surfaces through the consumer's pull anyway.
+- F4: wrap the supply object ONCE per worker (decorator responding to #shift), substituted at worker.rb:64 and as task's 2nd arg — covers all four sites, zero dsl.rb changes.
+- F5: criteria-bypass path automatically covered (intake happens before the branch).
+- F6: Fiber-local storage registry — YAGNI; `self` is available everywhere needed.
+- **F7 (CRITICAL): make_shareable does NOT reject IO or singleton-methoded objects.** Empirical: proc → Ractor::IsolationError; lazy enumerator → Ractor::Error; IO/File → silently frozen (shareable=true); OpenStruct, Data, singleton-methoded Object → silently frozen. §3.3/§10.1's claims that IO raises are wrong; UnshareableValue never fires for IO unless detection is proactive.
+- **F8: make_shareable(io) freezes the LIVE IO in place** — same object, process-wide: a shared logger/$stdout/file handle frozen for every reference in the process. Materially worse than raising. The :frozen/:isolated wrapper must check IO-like values and raise UnshareableValue proactively BEFORE calling make_shareable.
+- **F9: make_shareable(io, copy: true) duplicates the fd then freezes the duplicate** — new fd opened, unusable, never closed: one leaked fd per :isolated handoff of an IO. Same remedy as F8.
+- F10: singleton-methoded values: Marshal raises TypeError ("singleton can't be dumped") but make_shareable(copy: true) succeeds — a value that failed LOUDLY under :hardened silently succeeds under :isolated. Own migration-guide bullet, own spec.
+- F11: §8.2 short-circuit confirmed structurally: make_shareable(copy: true) returns the SAME object for an already-deeply-frozen Data instance (no copy). CPU amortization still needs §8.4 benchmarks.
+- F12: @context/BatchContext never crosses Fiber.yield (batch hands off collection.compact — a new array); stays mutable per §12. Confirmed out of scope.
+- F13: trailing_worker hands off `trail` itself (dsl.rb:125) while continuing to unshift/pop it → next resume raises FrozenError under :frozen. Fix: hand off `trail.dup`. Required Phase-1 shipped-code fix.
+- F14–F16: batch_worker safe (fresh array per batch + hands off .compact's new array); splitter_worker safe (fresh local per call, hands off elements); filter_worker safe (no closure state). Do NOT "fix" defensively — note as confirmed-safe in spec matrix.
+- F17: side_worker mode: :hardened is the only :hardened reference in the codebase; map to policy: :isolated with deprecation warning.
+- F18: §5.4's Worker#task= does not exist (only lazy `@task ||= default_task`); restate #freeze! motivation as supply=/Roster rewiring.
+- F19: #freeze! must force-materialize the lazy default task (invoke ensure_ready_to_work!) on every worker BEFORE freezing, else a default-task worker raises confusing FrozenError at first shift.
+- F20: #freeze! must also freeze Roster's @workers array — otherwise Gang#append/Roster#push still rewire topology (they set supply= on the NEW unfrozen worker and mutate the array).
+- F21: bare `|` chains have no Roster — Worker#freeze! must walk the .supply chain backward to nil to discover members. Two discovery mechanisms (Gang vs Worker); document which uses which.
+- F22: post-freeze supply= raises plain FrozenError, which is already unambiguous — do NOT add a TopologyFrozenError wrapper (YAGNI; reopen on migration feedback showing confusion).
+
+## test-engineer (house style: rspec-given Given/When/Then; raise_error(/regex/) + structured accessor checks; real values, no doubles for policy behavior)
+
+Load-bearing policy × shape matrix (equivalence classes, not the 3×10 product):
+1. :frozen × Array — `<<` raises PolicyViolation; receiver.equal?(value).
+2. :frozen × Hash-containing-Array — nested mutation raises; receiver reachable-but-not-equal (proves deep traversal, feeds heuristic).
+3. :frozen × Data (scalar members) — v.with(...) returns new frozen instance; original untouched.
+4. :frozen × nil — passthrough.
+5. :isolated × Array — task mutates its copy freely; output includes mutation; upstream original unaffected.
+6. :isolated × Data-with-mutable-Array-member — copy's member mutable without affecting original.
+7. :shared × Array — mutation visible to holders of the same reference.
+8. :shared × IO — passes through untouched, no error.
+Boundary cases: (9) mid-task supply.shift under upstream :frozen raises PolicyViolation like primary intake (filter_worker); (10) splitter under :frozen — EACH yielded part frozen, not just the last (fails against a naive single-site implementation, deliberately); (11) trailing_worker under :frozen default must not raise + previously-returned trail unaffected by later shifts (proves trail.dup fix); (12) side_worker(policy: :isolated) { |v| v << :boo } — original value continues unmutated (mirrors existing :hardened assertions); (13) criteria-bypass value still policy-applied (Medium).
+Error diagnostics: (14) PolicyViolation structured accessors .worker/.policy/.receiver + message content; (15) receiver heuristic three branches — equal / reachable / unrelated-FrozenError (report both objects, no misattribution; §6.2 answers this); (16) UnshareableValue guidance text matches /:shared/; (17) violation.cause is the original FrozenError (cheap, high regression value).
+Shim & failure sets: (18) :hardened → :isolated behavioral equivalence + deprecation warning emitted once per declaration (capture $stderr; no ActiveSupport); (19) table-driven :isolated failure-set spec over IO/Proc/Lazy/singleton — expected outcomes CANNOT be authored from the spec (F7!); requires an implementation spike on the target Ruby first.
+Meta-tests: (20) Testing.run uses worker's effective policy by default (build policy: :isolated worker, no override, assert isolated semantics); (21) explicit policy: override; (22) mutate_input matcher passes/fails against real workers using the real detector; (23) shared example "a policy-safe worker" passes known-good/fails known-bad. Keep behavioral — assert on outputs and raised errors, not on how run() invokes make_shareable.
+Existing-suite impact: (24) dsl_spec.rb:149–164 `proc { |v| v << :boo }` breaks under :frozen → rewrite non-destructively (v + [:boo]) AND add companion spec with explicit policy: :shared preserving old behavior (the migration worked example); (25) dsl_spec.rb:166–174 :hardened context → retarget to :isolated, keep thin shim regression; (26) dsl_spec.rb:317–341 trailing_worker passes once trail.dup fix lands + new aliasing assertion. worker/gang/roster specs confirmed mutation-free — pass unmodified.
+File layout: lib/shifty/testing.rb → spec/shifty/testing_spec.rb; shared-example spec under spec/support/; matcher spec separate. Skipped (with triggers): nil × isolated/shared; String cells (same class as Array); full cartesian; identity-keyed-cache caveat (§11.2, no trigger); shareable? fast path (deferred by decision); PolicyConflict tests (now dropped per user).
+
+## junior-developer (F1–F13)
+
+F1: "major version" language needs 0.x translation; F1a :hardened removal horizon undefined (user: 1.0.0); F1b "vNEXT" placeholders → 0.6.0.
+F2: §5.4 assumes Worker#task= which doesn't exist.
+F3: four handoff sites, spec targets only one (resolved by A1/F4 ingress design).
+F4: trailing_worker/side_worker are shipped code broken under :frozen; phase assignment needed (→ Phase 1).
+F5: main shipped-inconsistent between PRs — OK if nothing is released; version bump + CHANGELOG land in the Phase-4 release PR.
+F6: wiki page list/audience/split undefined (user approved 7-page set).
+F7: CI matrix ruby.yml:21 = ['2.6','2.7','3.0'] — zero supported Rubies once floor is 3.2; matrix → ['3.2','3.3','3.4']; actions/checkout@v2 and SHA-pinned setup-ruby stale. Release blocker; Phase 1.
+F8: codeclimate-test-reporter pins simplecov ≤ 0.13 (2016), abandoned — drop while touching gemspec.
+F9: gemspec lacks required_ruby_version; add >= 3.2 together with CI change.
+F10: benchmark suite: no home/run-mode/dep decided; §8.2 amortization is load-bearing-but-unvalidated for the default; benchmarks land Phase 3 — if they contradict §8.2, revisit default before release.
+F11: stray .gem files in root/pkg (untracked, gitignored); Gemfile.lock gitignored (conventional for gems); release-phase sweep.
+F12: mutation detector + matcher + shared example sized; keep detector (powers migration tooling); both RSpec constructs are thin wrappers (kept per spec/user commitment).
+F13: name: vs tags (kept per §5.5); PolicyConflict vacuous (user: dropped); #freeze! justification corrected to supply=/Roster (kept, Phase 3).

--- a/docs/planning/artifacts/implementation-decision-log.md
+++ b/docs/planning/artifacts/implementation-decision-log.md
@@ -1,0 +1,231 @@
+# Implementation Decision Log: Handoff Immutability Policies
+
+<!--
+This file records every implementation decision committed while planning Handoff Immutability Policies.
+Behavioral and implementation statements live in [../feature-implementation-plan.md](../feature-implementation-plan.md) —
+this file captures the question, rationale, evidence, and rejected alternatives for each decision.
+Round-by-round history lives in [implementation-iteration-history.md](implementation-iteration-history.md).
+Source spec: [../handoff-immutability-policies.md](../handoff-immutability-policies.md).
+Verbatim specialist outputs (referenced by A#/F#/test-# below): [.round1-specialist-outputs.md](.round1-specialist-outputs.md).
+
+The D-N counter is shared across the trivial and full sections.
+-->
+
+## Trivial decisions
+
+- D-14: `name:` kwarg retained (§5.5) — workers gain an optional `name:` for diagnostics alongside existing tags; kept per spec commitment and Joel's full-scope decision, no alternative worth debating. — Referenced in plan: Implementation Approach (Policy module and diagnostics).
+- D-15: Seven-page wiki set — Home, Handoff-Policies, Coding-Idioms-Under-Frozen, Migration-Guide-0.6, Testing-Workers, Worker-Types, Performance; drafted under `docs/wiki/`, pushed to the GitHub wiki repo after merge; README slims to a quick tour plus links (Joel, R2). — Referenced in plan: Decomposition and Sequencing (PR 4).
+- D-16: Drop `codeclimate-test-reporter` — the dev dep pins simplecov ≤ 0.13 (2016-era) and is effectively abandoned; removed while the gemspec is already open in PR 1 (junior-developer F8/C20). — Referenced in plan: Decomposition and Sequencing (PR 1).
+- D-17: Real values, no doubles for policy behavior — policy specs assert on real frozen/copied values and raised errors, not on how the framework invokes `make_shareable`; matches the repo's rspec-given house style (test-engineer). — Referenced in plan: Testing Strategy.
+- D-18: `shifty/testing` and `shifty/rspec` as separate opt-in requires — neither is loaded by `require "shifty"`; pure-Ruby harness split from the RSpec sugar (software-architect A6/C13). — Referenced in plan: Implementation Approach (testing layering), Decomposition and Sequencing (PR 2).
+- D-19: Global configuration object — `Shifty::Configuration` with `default_policy` (built-in `:frozen`) plus `Shifty.configure`/`config`/`reset_configuration!`; API shape committed by Joel, effective policy memoized at first shift (software-architect A5/C12). — Referenced in plan: Implementation Approach (config), Decomposition and Sequencing (PR 1).
+- D-20: `side_worker` accepts both `mode:` and `policy:` spellings — the lone `mode: :hardened` reference (dsl.rb:35) routes through `Policy.canonical` to `:isolated` with a one-time deprecation warning; both spellings pass through DSL option-splatting (software-architect A7, concurrency F17/C8). — Referenced in plan: Implementation Approach, Decomposition and Sequencing (PR 1).
+- D-21: Mutation detector plus both RSpec constructs ship in PR 2 — the detector powers migration tooling, and the `mutate_input` matcher and `"a policy-safe worker"` shared example are both thin wrappers over it; kept per spec §9.3 and Joel's full-scope decision (junior-developer F12/C23 Disputed→resolved). — Referenced in plan: Implementation Approach (testing layering), Testing Strategy, Decomposition and Sequencing (PR 2).
+- D-22: Release-phase repo sweep — remove stray `.gem` artifacts from repo root / `pkg`; confirm `Gemfile.lock` stays gitignored (conventional for a gem); housekeeping folded into PR 4 (junior-developer F11/C21). — Referenced in plan: Decomposition and Sequencing (PR 4).
+
+## Full decisions
+
+### D-1: Ingress-seam enforcement via PolicySupply decorator
+
+- **Question:** Where in the worker runtime is a handoff policy applied so that every value crossing a worker boundary is governed exactly once?
+- **Decision:** Apply policy at the **consuming worker's intake** (its supply pull), not at the producer's egress. Introduce a single `intake(value)` seam wrapping `worker.rb:64` (`value = supply&.shift`) and a thin `PolicySupply` decorator (responding to `#shift` as `intake(supply.shift)`) substituted as the task's 2nd argument at `worker.rb:66`. This covers all four `supply.shift` read sites (worker.rb:64; dsl.rb:55 filter, dsl.rb:86 batch, dsl.rb:122 trailing) with zero dsl.rb task-body changes. Producer-side `handoff`/`Fiber.yield` sites (source_worker, splitter_worker) get no instrumentation.
+- **Rationale:** §6.2 names the *receiving* worker in the error, so policy is a property of how a worker receives its value. Every value a producer yields surfaces through some consumer's pull, so the consumer intake is the complete and minimal enforcement set; no value crosses twice, so `:isolated` never double-copies. Wrapping the supply once per worker satisfies the Rule of Three (three in-task `supply.shift` uses exist today) without touching task bodies. §7.3 aliasing is still caught: `make_shareable` freezes the actual object in place, so a producer that keeps mutating a handed-off object raises at the producer.
+- **Evidence:** Independent convergence of software-architect A1 and concurrency-analyst F1–F4 (see [.round1-specialist-outputs.md](.round1-specialist-outputs.md)); enforcement sites enumerated at worker.rb:64/66, dsl.rb:55/86/122; discovery notes on the four `supply.shift` sites and producer-side `handoff`. C1–C3.
+- **Rejected alternatives:**
+  - Freeze at the single egress site (`Fiber.yield @task.call(...)`, worker.rb:66) — rejected because it misses in-task `supply.shift` in filter/batch/trailing workers and makes the *producer's* policy govern the boundary, contradicting §5.2 (worker declarations are the receiver's contract). Evidence: A1, F1.
+  - Instrument `handoff`/`Fiber.yield` producer sites — rejected because `handoff` is a free DSL function with no access to the executing worker, and every internal yield already surfaces at the consumer's pull (double coverage, no gain). Evidence: F3.
+- **Specialist owner:** software-architect (design), concurrency-analyst (handoff-site correctness).
+- **Revisit criterion:** A future worker type that consumes values without a `supply.shift` intake (e.g. a Ractor-backed worker, §11.6) would need a new enforcement seam.
+- **Dissent (if any):** None — specialists converged.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** D-2, D-3, D-4, D-7, D-12, D-13.
+- **Referenced in plan:** Implementation Approach (Architecture and Integration Points; Runtime Behavior), Decomposition and Sequencing (PR 1).
+
+### D-2: Proactive IO detection for UnshareableValue
+
+- **Question:** How is `UnshareableValue` (§6.2) raised for IO handles, sockets, and similar values, given the spec's stated assumption that `make_shareable` rejects them?
+- **Decision:** Detect IO-like values **proactively** in the `:frozen` and `:isolated` apply paths and raise `Shifty::UnshareableValue` *before* calling `Ractor.make_shareable`. Do not rely on `make_shareable` raising. Proc and `Enumerator::Lazy` continue to raise naturally and are wrapped as `UnshareableValue`.
+- **Rationale:** Empirical testing refutes spec §3.3/§10.1: `make_shareable` does **not** reject IO or singleton-methoded objects. It silently freezes a live IO in place — a process-wide side effect freezing a shared `$stdout`/logger/file handle for every reference in the process (materially worse than raising), and `copy: true` on an IO duplicates the fd, freezes the copy, and leaks one unusable fd per handoff. The spec's *intent* (UnshareableValue for uncopyable values) is preserved only if detection is proactive.
+- **Evidence:** concurrency-analyst F7 (CRITICAL), F8, F9, F10 — empirical on Ruby 4.0.5; C4, C5. Re-verification on the Ruby 3.2 CI floor is a PR-1 spike task (see D-8).
+- **Rejected alternatives:**
+  - Trust the spec and let `make_shareable` reject IO — rejected: empirically false; it silently freezes live IO process-wide (F8) and leaks fds under `copy: true` (F9).
+  - Reactive-only wrapping (catch whatever `make_shareable` raises) — rejected: for IO nothing is raised, so the damage is done silently before any wrap could fire (F7/F8).
+- **Specialist owner:** concurrency-analyst.
+- **Revisit criterion:** If the PR-1 spike on Ruby 3.2 finds `make_shareable` behavior differs materially from the 4.0.5 observations, the detection predicate and the `:isolated` failure-set table (test #19) are re-derived from the spike results.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** D-5, D-8, D-13.
+- **Referenced in plan:** Implementation Approach (Runtime Behavior; empirical spike), RAID Log (assumptions/risks), Testing Strategy.
+
+### D-3: Policy as three frozen singletons
+
+- **Question:** What structure implements the three policies and their name resolution (including the `:hardened` alias)?
+- **Decision:** A `Shifty::Policy` module holding three frozen singleton lambdas (`Frozen`, `Isolated`, `Shared`) behind `Policy.resolve(name)`, with a `TABLE` and an `ALIASES = {hardened: :isolated}` map; `canonical(name)` applies aliases and the `:hardened` deprecation warning. Not a class hierarchy, not a mixin. Each apply wraps `make_shareable`/Marshal failures (and the proactive IO check from D-2) as `UnshareableValue`.
+- **Rationale:** Policy is a collaborator, not worker state (contrast the `Taggable` mixin), so a module of stateless strategies is the smallest fit. `resolve`/`ALIASES` gives one place for validation and the deprecation shim. Three concrete policies exist today — no speculative extensibility.
+- **Evidence:** software-architect A2; C9. Existing `Taggable` mixin precedent in `lib/shifty/taggable.rb` (discovery notes).
+- **Rejected alternatives:**
+  - Class hierarchy of policy objects — rejected: no per-instance state to hold; adds ceremony over three stateless lambdas (A2).
+  - Mixin on Worker (Taggable-style) — rejected: policy is a collaborator applied to values, not worker identity/state (A2).
+- **Specialist owner:** software-architect.
+- **Revisit criterion:** A fourth policy, or per-policy configuration state, would justice a richer object model.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** D-4, D-9, D-20.
+- **Referenced in plan:** Implementation Approach (Policy module), Decomposition and Sequencing (PR 1).
+
+### D-4: Two-attribute policy precedence
+
+- **Question:** How is the worker > pipeline > global precedence (§5.2) represented and how does `.with_policy` propagate?
+- **Decision:** Two nullable attributes on Worker — `@policy` (explicit contract) and `@pipeline_policy` (default) — resolved by `Policy.resolve(@policy || @pipeline_policy || Shifty.config.default_policy)`, memoized in `effective_policy`. `.with_policy(name)` validates eagerly, then walks the `.supply` chain upstream setting `pipeline_policy=` on each node; Gang fans `pipeline_policy=` out across its roster and `Gang#supply` returns `roster.first.supply` so the walk steps past a gang.
+- **Rationale:** Two attributes let a nil `@policy` mean "undeclared" without a separate `declared?` flag or branching. There is no chain object for bare `|` chains — a pipeline is just the last worker (discovery notes) — so `.with_policy` must live on Worker and Gang and propagate via the supply chain. Workers do not know their consumer, so propagation walks upstream, not down.
+- **Evidence:** software-architect A3; C9. Discovery notes: composition links workers by setting `supply`; no pipeline object exists; Gang is the only reifying container.
+- **Rejected alternatives:**
+  - Single `@policy` plus a `declared?` flag — rejected: forces branching everywhere the flag is read (A3).
+  - Store policy by walking downstream to the consumer — rejected: workers hold no reference to their consumer, only to their supply (A3).
+- **Specialist owner:** software-architect.
+- **Revisit criterion:** A reified pipeline/chain object (if introduced later) would relocate `.with_policy` off Worker.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** D-19.
+- **Referenced in plan:** Implementation Approach (precedence), Decomposition and Sequencing (PR 1).
+
+### D-5: Consolidated error hierarchy
+
+- **Question:** Where do the new and existing error classes live, and under what base?
+- **Decision:** Consolidate errors into `lib/shifty/errors.rb` under a `Shifty::Error` base, with a `PolicyError` intermediate: `PolicyViolation < PolicyError` (attrs: worker, policy, receiver, value, cause) and `UnshareableValue < PolicyError` (attrs: worker, policy, value). Reparent existing `WorkerError`/`WorkerInitializationError` under `Shifty::Error` (source-compatible) and move `WorkerInitializationError` out of dsl.rb. No `PolicyConflict` class (see D-6).
+- **Rationale:** A single error file with a common base is idiomatic and lets callers rescue `Shifty::Error` broadly or `PolicyError` narrowly. Reparenting is source-compatible because the existing classes keep their names.
+- **Evidence:** software-architect A4; C10. `PolicyViolation`/`UnshareableValue` attribute lists from spec §6.2.
+- **Rejected alternatives:**
+  - Leave errors scattered across dsl.rb and worker.rb — rejected: no common ancestor for `rescue`, and the new policy errors need a home anyway (A4).
+  - Include a `PolicyConflict` class — rejected: nothing to raise it (see D-6).
+- **Specialist owner:** software-architect.
+- **Revisit criterion:** A new error family (e.g. topology errors) would extend, not revise, this hierarchy.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** D-2, D-6.
+- **Referenced in plan:** Implementation Approach (errors), Decomposition and Sequencing (PR 1).
+
+### D-6: PolicyConflict dropped entirely
+
+- **Question:** Does the plan ship a `PolicyConflict` class and build-time validation (spec §5.3, Phase 2)?
+- **Decision:** Drop `PolicyConflict` entirely — no class, no validation.
+- **Rationale:** The committed precedence rule (worker declarations authoritative, pipeline policy default-only, §11.4) leaves no violable rule to enforce, so there is nothing to raise. Joel (R2): "Since we're defaulting to frozen and allowing workers to opt out to something more permissive, we don't have a PolicyConflict... nothing to raise means no class, and we'll revisit later if we need to refine this."
+- **Evidence:** User input, R2 (verbatim above). software-architect A4 and junior-developer F13/C11 independently flagged the class as vacuous.
+- **Rejected alternatives:**
+  - Define the class now, defer only the detection logic — rejected: a class with no raiser is dead code future agents would copy; Joel chose to drop it outright (R2).
+  - Implement full build-time validation now — rejected: no rule exists to validate under the committed precedence semantics (A4, C11).
+- **Specialist owner:** software-architect.
+- **Revisit criterion:** A strict-Gang feature (§11.4) that lets a pipeline *forbid* worker-level loosening — that would introduce a violable rule and reopen the need for both the class and detection.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1 (flagged), R2 (decided).
+- **Dependent decisions:** —.
+- **Referenced in plan:** Implementation Approach (errors), Decomposition and Sequencing (PR 2 scope note), Deferred (YAGNI).
+
+### D-7: trailing_worker aliasing fix in Phase 1
+
+- **Question:** `trailing_worker` (dsl.rb:112–130) hands off its live closure `trail` array while continuing to `unshift`/`pop` it — under the `:frozen` default the next resume raises `FrozenError`. Where and how is this fixed?
+- **Decision:** Fix the shipped worker in **PR 1** to hand off `trail.dup` (a snapshot), not the live array. batch/splitter/filter workers are confirmed safe as written and are **not** defensively changed.
+- **Rationale:** This is exactly the aliasing bug class the policy exists to catch (§7.3), but it is in Shifty's own shipped DSL, so it must be fixed rather than merely documented. It travels with the mechanism (PR 1) because the `:frozen` default lands there. batch (fresh array + `.compact` new array), splitter (fresh local per call), and filter (no closure state) do not alias, so touching them would add risk for no benefit.
+- **Evidence:** concurrency-analyst F13–F16 (trailing aliases at dsl.rb:125; others safe); junior-developer F4; test-engineer #11/#26; C7.
+- **Rejected alternatives:**
+  - Internally declare `trailing_worker policy: :shared` — rejected: masks the aliasing instead of fixing it, and denies trailing_worker users the `:frozen` guarantee (software-architect A7).
+  - Leave it and document as a known break — rejected: it is first-party code; shipping a framework whose own DSL breaks under its own default is not acceptable.
+- **Specialist owner:** concurrency-analyst.
+- **Revisit criterion:** None expected; regression is guarded by test #26.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** D-12, D-13.
+- **Referenced in plan:** Implementation Approach (Runtime Behavior), Decomposition and Sequencing (PR 1), Testing Strategy.
+
+### D-8: Ruby 3.2 floor and CI matrix in Phase 1
+
+- **Question:** Which PR owns `required_ruby_version >= 3.2` and the CI matrix rewrite?
+- **Decision:** Land `required_ruby_version >= 3.2` in the gemspec and rewrite the CI matrix from `['2.6','2.7','3.0']` to `['3.2','3.3','3.4']` (plus refreshing stale `actions/checkout@v2` and the SHA-pinned setup-ruby) in **PR 1**, as a prerequisite to trusting any policy spec. The PR-1 spike re-verifies the D-2 `make_shareable` observations on the 3.2 floor.
+- **Rationale:** The current matrix tests only Rubies *below* the new floor, so without this change every policy spec runs on unsupported, wrong-behavior Rubies. `Data` idioms (§7.2) and mature `make_shareable` need ≥ 3.2. This is a release blocker that gates the correctness of everything else in PR 1.
+- **Evidence:** junior-developer F7, F9; C15; resolved by evidence/aggregation (OQ-4). CI matrix at `.github/workflows/ruby.yml:21`; gemspec lacks `required_ruby_version` (discovery notes).
+- **Rejected alternatives:**
+  - Put CI/gemspec changes in the Phase-4 release PR — rejected: policy specs in PRs 1–3 would run on unsupported Rubies with different `make_shareable`/Data behavior, invalidating them (F7, OQ-4).
+  - A separate prerequisite PR before PR 1 — rejected: adds a fifth PR for a change that naturally belongs with the mechanism it enables; one-PR-per-phase is the committed shape.
+- **Specialist owner:** junior-developer (raised); PM (sequencing).
+- **Revisit criterion:** None; floor is fixed for the 0.6.0 line.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** D-2.
+- **Referenced in plan:** Decomposition and Sequencing (PR 1), RAID Log.
+
+### D-9: :hardened deprecation horizon
+
+- **Question:** In 0.x terms, when is the deprecated `:hardened` option removed?
+- **Decision:** `:hardened` is **deprecated in 0.6.0** (mapped to `:isolated` with a one-time warning via `Policy.canonical`) and **removed at 1.0.0**. Docs state "deprecated in 0.6.0, removed in 1.0.0."
+- **Rationale:** The spec speaks of "one major version, then removed," which is undefined in a pre-1.0 line. Joel (R2) set the concrete horizon: keep the shim through the 0.x series and drop it at the 1.0.0 boundary, which is the natural major-version break.
+- **Evidence:** User input, R2. junior-developer F1/C16 flagged the undefined 0.x horizon (OQ-1).
+- **Rejected alternatives:**
+  - Remove at the next minor (0.7.0) — rejected: too aggressive for a deprecation users have not yet seen; Joel chose the 1.0.0 boundary (R2).
+  - Keep indefinitely — rejected: leaves a dead alias and the Marshal-divergence caveat (C5) live forever (R2).
+- **Specialist owner:** software-architect (shim), PM (horizon).
+- **Revisit criterion:** If 1.0.0 slips materially, re-confirm the removal still rides that release.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1 (flagged), R2 (decided).
+- **Dependent decisions:** D-20.
+- **Referenced in plan:** Implementation Approach, Decomposition and Sequencing (PR 1), Deferred/Migration notes.
+
+### D-10: Manual-run benchmark directory
+
+- **Question:** Where do the §8.4 benchmarks live, how are they run, and what dependency do they add?
+- **Decision:** A `benchmark/` directory with `benchmark-ips` as a **dev** dependency, **manual-run** (not in CI), results published to the wiki Performance page. Benchmarks land in **PR 3**. If they contradict the §8.2 amortization claim, the `:frozen` default is revisited before release.
+- **Rationale:** The §8.2 amortization claim is load-bearing for choosing `:frozen` as default but is uncited until measured. Running benchmarks in CI would make the suite slow and flaky for a measurement that is consulted occasionally; manual runs with published results fit a gem with no perf SLO.
+- **Evidence:** junior-developer F10/C19/C6; resolved by aggregation (OQ-6). No benchmark tooling exists today (discovery notes).
+- **Rejected alternatives:**
+  - CI-run benchmarks — rejected: slow/flaky CI for an occasionally-consulted measurement; replaced by manual runs + published results (OQ-6).
+  - Skip benchmarks — rejected: the default-policy choice rests on the unvalidated §8.2 claim (F10); measurement is required before release.
+- **Specialist owner:** junior-developer (raised); PM (sequencing).
+- **Revisit criterion:** Benchmarks show `:frozen` amortization does not hold on representative value shapes → revisit the default before 0.6.0 ships (RAID R1).
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** —.
+- **Referenced in plan:** Decomposition and Sequencing (PR 3), RAID Log, Deferred (YAGNI) (CI-run benchmarks).
+
+### D-11: Version bump and CHANGELOG in Phase-4 PR
+
+- **Question:** When do the version bump to 0.6.0 and the CHANGELOG entry land, given one PR per phase and shipped-but-unreleased `main` between PRs?
+- **Decision:** The version bump (`lib/shifty/version.rb` → 0.6.0) and the CHANGELOG entry land in the **Phase-4 (release) PR**, together with the README rewrite, wiki drafts, PR-26 doc reconciliation, and the gem build. `main` may carry unreleased behavior between PRs 1–3.
+- **Rationale:** Nothing is published until Joel builds and pushes 0.6.0, so `main` being shipped-but-not-yet-released between phase PRs is harmless; deferring the version/CHANGELOG to the release PR keeps a single coherent release note rather than four partial bumps. This is a process-convention call, not an evidenced one.
+- **Evidence:** junior-developer F5/C17 (Anecdotal — process convention); reframed the release-timing question, resolved by convention (OQ-5).
+- **Rejected alternatives:**
+  - Bump version per-phase PR — rejected: four intermediate versions for one logical release; no publish happens between them so the bumps carry no signal (F5).
+- **Specialist owner:** junior-developer (reframed); Joel (publishes).
+- **Revisit criterion:** If any phase PR is released independently, that PR must carry its own bump/CHANGELOG.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** —.
+- **Referenced in plan:** Decomposition and Sequencing (PR 4), Definition of Done.
+
+### D-12: Terminal output governance out of scope
+
+- **Question:** The value the last worker's `shift` returns to user code crosses no consumer intake and is therefore un-governed by any policy. Is that a gap to close?
+- **Decision:** Leave terminal output un-governed; document it in the wiki/migration guide. No framework mechanism wraps the final `shift`.
+- **Rationale:** Spec §2 scopes policies to *worker boundaries*; the terminal caller is not a worker, so there is no boundary to govern. The one shipped aliasing hazard at the terminal (trailing_worker) is removed by D-7, so the residual is documentation only.
+- **Evidence:** aggregator synthesis from A1/F1; C25; resolved by evidence against spec §2 scoping.
+- **Rejected alternatives:**
+  - Govern terminal output by wrapping the final `shift` — rejected: the terminal caller is outside the worker-boundary model the policies are scoped to (§2); adding a special case there would be scope creep with no boundary to protect (C25).
+- **Specialist owner:** software-architect.
+- **Revisit criterion:** If a use case emerges where user code downstream of the last worker needs the same mutation guarantees, reconsider a terminal policy.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** —.
+- **Referenced in plan:** Implementation Approach (Runtime Behavior), Decomposition and Sequencing (PR 4, wiki).
+
+### D-13: Equivalence-class test matrix
+
+- **Question:** How much of the policy × value-shape space does the test suite cover?
+- **Decision:** Cover **8 load-bearing equivalence-class cells** (not the full 3×10 cartesian), plus 5 boundary-case behaviors (#9–13), 4 error-diagnostic contracts (#14–17), the deprecation shim + a table-driven `:isolated` failure-set spec (#18–19), 4 meta-tests for the testing harness (#20–23), and 3 existing-spec migrations (#24–26). The `:isolated` failure-set table (#19) cannot be authored from the spec and requires an implementation spike on the target Ruby first (per D-2). Real values throughout, no doubles.
+- **Rationale:** The full cartesian is mostly redundant — String behaves as Array, nil × isolated/shared is trivial — so equivalence classes give the same confidence at a fraction of the maintenance. The failure-set table must be spiked because the spec's rejection claims are empirically wrong (D-2).
+- **Evidence:** test-engineer full prioritized plan; C22. Existing specs that break under `:frozen`: dsl_spec.rb:149–164, 166–174, 317–341.
+- **Rejected alternatives:**
+  - Full 3×10 policy × value-shape cartesian — rejected: String duplicates Array, nil cells are trivial passthrough; equivalence classes cover the load-bearing behavior with far less to maintain (test-engineer).
+- **Specialist owner:** test-engineer.
+- **Revisit criterion:** A new value shape with distinct freeze/copy behavior (outside the existing equivalence classes) adds a cell.
+- **Dissent (if any):** None.
+- **Driven by rounds:** R1.
+- **Dependent decisions:** —.
+- **Referenced in plan:** Testing Strategy, Decomposition and Sequencing (all PRs).

--- a/docs/planning/artifacts/implementation-iteration-history.md
+++ b/docs/planning/artifacts/implementation-iteration-history.md
@@ -1,0 +1,73 @@
+# Implementation Iteration History: Handoff Immutability Policies
+
+<!--
+This file records how the implementation plan evolved across discussion rounds.
+Committed decisions live in [implementation-decision-log.md](implementation-decision-log.md)
+and the primary plan lives in [../feature-implementation-plan.md](../feature-implementation-plan.md).
+Source spec: ../handoff-immutability-policies.md (design doc; no plan-a-feature artifacts,
+so no T# technical notes exist and the T#-contradiction classification does not apply).
+-->
+
+## R1: Parallel specialist review
+
+- **Specialists engaged:** concurrency-analyst, software-architect, test-engineer, junior-developer (project-manager reserved for synthesis; deterministic aggregation used per skill).
+- **New input provided:** Initial feature spec (`../handoff-immutability-policies.md`), discovery notes (`.discovery-notes.md`), and Joel's nine committed decisions (0.6.0, all four phases, Ruby ≥ 3.2 floor, API shape, one PR per phase, wiki via docs/wiki/, :hardened→:isolated, no shareable? fast path, Joel publishes gem).
+
+- **Claim ledger:**
+
+| # | Claim | Raised by | Category | State |
+|---|-------|-----------|----------|-------|
+| C1 | Policy must be enforced at the consumer's intake (supply pull), via a supply-wrapping decorator substituted at worker.rb:64 and as the task's 2nd arg at worker.rb:66; covers all four `supply.shift` sites (worker.rb:64, dsl.rb:55, dsl.rb:86, dsl.rb:122) with zero dsl.rb task-body changes | concurrency-analyst (F1–F4), software-architect (A1) — independent convergence | design | Evidenced |
+| C2 | Producer-side `handoff`/`Fiber.yield` sites (source_worker, splitter_worker) need no instrumentation — every yielded value surfaces through the consumer's pull | concurrency-analyst (F3), software-architect (A1) | design | Evidenced |
+| C3 | criteria-bypass path (worker.rb:68) is automatically covered by intake-side enforcement | concurrency-analyst (F5) | edge-case | Evidenced |
+| C4 | **Spec §3.3/§10.1 are factually wrong**: `make_shareable` does NOT reject IO or singleton-methoded objects — it silently freezes live IO in place (process-wide side effect) and `copy: true` on IO leaks a file descriptor. Only Proc and Enumerator::Lazy raise. UnshareableValue must be raised proactively for IO-like values | concurrency-analyst (F7–F9), empirical on Ruby 4.0.5 | assumption-refuted | Evidenced (re-verify on 3.2 CI) |
+| C5 | Marshal-vs-make_shareable divergence includes a silent-behavior-change case: singleton-methoded values failed loudly under :hardened (Marshal) but silently succeed under :isolated (make_shareable) — migration guide must call this out separately | concurrency-analyst (F10) | edge-case | Evidenced |
+| C6 | §8.2 already-shareable short-circuit confirmed structurally (copy: true returns same object for frozen Data); CPU amortization claim still needs §8.4 benchmarks | concurrency-analyst (F11), junior-developer (F10) | ambiguity | Evidenced (partial) |
+| C7 | trailing_worker (dsl.rb:112–130) hands off its live closure array and breaks under :frozen — required Phase-1 shipped-code fix (`trail.dup`); batch/splitter/filter workers confirmed safe as written | concurrency-analyst (F13–F16), junior-developer (F4), test-engineer (#11) | edge-case | Evidenced |
+| C8 | side_worker `mode: :hardened` (dsl.rb:35,40–41) maps to policy: :isolated with deprecation warning via Policy.canonical; shim must accept both `mode:` and `policy:` spellings | concurrency-analyst (F17), software-architect (A7), test-engineer (#18) | design | Evidenced |
+| C9 | Policy strategies as three frozen singletons in `Shifty::Policy` with `resolve(name)` + ALIASES; not a class hierarchy, not a mixin; precedence as two nullable attributes (@policy contract, @pipeline_policy default) resolved by `||`-chain; `.with_policy` walks the supply chain upstream, Gang fans out to roster | software-architect (A2, A3) | design | Evidenced |
+| C10 | Errors consolidate into lib/shifty/errors.rb under Shifty::Error base with PolicyError intermediate; existing WorkerError/WorkerInitializationError reparented (source-compatible) | software-architect (A4) | design | Evidenced |
+| C11 | `PolicyConflict` build-time validation has nothing to enforce: committed decision (worker wins, pipeline default-only, §11.4) leaves no violable rule. Define the class, defer the detection | software-architect (A4), junior-developer (F13) | YAGNI-candidate | Evidenced |
+| C12 | Global config: `Shifty::Configuration` object + `Shifty.configure`/`config`/`reset_configuration!`; effective policy memoized at first shift | software-architect (A5) | design | Evidenced |
+| C13 | shifty/testing (pure Ruby) and shifty/rspec (opt-in) as separate requires, neither loaded by `require "shifty"` | software-architect (A6) | design | Evidenced |
+| C14 | §5.4 cites a `Worker#task=` writer that does not exist; #freeze! motivation must be restated (supply= + Roster rewiring). #freeze! must (a) force-materialize lazy @task first, (b) freeze Roster @workers array, (c) walk .supply chain for bare `\|` chains | concurrency-analyst (F18–F21), junior-developer (F2) | assumption-refuted + design | Evidenced |
+| C15 | CI matrix (.github/workflows/ruby.yml:21) tests only 2.6/2.7/3.0 — zero supported Rubies under the 3.2 floor; matrix rewrite + required_ruby_version are a Phase-1 prerequisite, plus stale actions | junior-developer (F7, F9) | assumption-refuted | Evidenced |
+| C16 | "major version" language throughout spec needs 0.x translation; :hardened removal horizon ("one major version, then removed") is undefined in 0.x terms | junior-developer (F1) | spec-level | Evidenced |
+| C17 | main will be shipped-but-undocumented-inconsistent between phase PRs; version bump + CHANGELOG should land in the Phase-4 (release) PR | junior-developer (F5) | ambiguity | Anecdotal (process convention) |
+| C18 | Wiki page list, audience, and README/wiki split undefined; docs/wiki/ doesn't exist; information-architect input recommended at Phase 4 | junior-developer (F6) | spec-level | Evidenced |
+| C19 | Benchmark suite has no home/run-mode/dependency decision; §8.2 amortization is load-bearing-but-uncited for the :frozen default | junior-developer (F10) | ambiguity | Evidenced |
+| C20 | codeclimate-test-reporter dev dep pins simplecov ≤ 0.13 (2016-era), effectively abandoned — drop while touching gemspec | junior-developer (F8) | edge-case | Evidenced |
+| C21 | Stray .gem files in repo root / pkg; Gemfile.lock gitignored (conventional for a gem) — release-phase sweep item | junior-developer (F11) | polish | Evidenced |
+| C22 | Test plan: 8 load-bearing policy×shape equivalence-class cells (not full cartesian), 4 boundary-case behaviors, 4 error-diagnostic contracts, deprecation shim + empirical failure-set table (spike required before authoring), meta-tests for Testing.run/matcher/shared example, 3 existing specs break under :frozen default (dsl_spec.rb:151, 166–174, 317–341) and double as migration worked examples; real values throughout, no doubles | test-engineer (full plan) | test-coverage | Evidenced |
+| C23 | Mutation detector + both RSpec constructs sized as large Phase-2 surface; matcher and shared example both ship vs one | junior-developer (F12) vs spec §9.3 commitment | YAGNI-candidate | Disputed (resolved: spec + user committed all; both are thin wrappers over the detector) |
+| C24 | name: kwarg (§5.5) vs existing tags for diagnostics | junior-developer (F13) | YAGNI-candidate | Resolved by spec commitment (§5.5, user decision: full scope) |
+| C25 | Terminal-output governance: under intake-side enforcement, the value returned by the LAST worker's `shift` to user code crosses no consumer intake and is un-governed | aggregator (from A1/F1 synthesis) | edge-case | Resolved by evidence: spec §2.1 scopes policies to worker boundaries; terminal caller is not a worker. Document in wiki/migration guide; trailing_worker fix (C7) removes the one shipped aliasing hazard |
+
+- **Open Questions raised:**
+  - OQ-1 (from C16): What is the :hardened removal horizon in 0.x terms? → escalate to user with recommendation "removed at 1.0.0".
+  - OQ-2 (from C11): Defer PolicyConflict detection logic (class only) — deviation from spec §13 Phase 2 scope? → escalate to user with recommendation "defer with reopening trigger".
+  - OQ-3 (from C18): Wiki page list and README/wiki split → propose page list to user.
+  - OQ-4 (from C15): Which phase owns CI matrix + required_ruby_version? → resolved by evidence/aggregation: Phase 1 PR (prerequisite for trusting policy specs on supported Ruby).
+  - OQ-5 (from C17): Version bump + CHANGELOG timing → resolved by convention: Phase-4 release PR; main may carry unreleased behavior between PRs since nothing is published until 0.6.0.
+  - OQ-6 (from C19): Benchmark home/run-mode → resolved by aggregation: `benchmark/` directory, benchmark-ips as dev dependency, manual-run (not CI), results published to wiki Performance page; if results contradict §8.2 the default is revisited before release (risk logged).
+  - OQ-7 (from C4): Spec correction for make_shareable rejection set → resolved by evidence: spec *intent* (UnshareableValue for IO) is preserved via proactive IO detection in Policy application; spec doc + README/wiki text corrected in Phase 4. Empirical re-verification on Ruby 3.2 CI is a Phase-1 spike task.
+- **Spec-maturity tags:** plan-level: C1–C15, C17, C19–C25 (majority); spec-level: C16 (junior-developer), C18 (junior-developer). 2 spec-level findings from 1 specialist — **gate NOT tripped** (threshold: ≥5 from ≥3 specialists). No T# notes exist, so T#-contradiction does not apply.
+- **Resolution source:** OQ-4, OQ-5, OQ-6, OQ-7, C25 — evidence/deterministic aggregation. OQ-1, OQ-2, OQ-3 — user input (batched escalation, see R2).
+- **Decisions produced:** D-1, D-2, D-3, D-4, D-5, D-7, D-8, D-10, D-11, D-12, D-13 (full); D-14, D-16, D-17, D-18, D-19, D-20, D-21, D-22 (trivial). D-6 and D-9 flagged this round (C11→OQ-2, C16→OQ-1) but decided in R2.
+- **Changed in plan:** Implementation Approach; Decomposition and Sequencing; RAID Log; Testing Strategy; Definition of Done; Deferred (YAGNI).
+- **Next-step recommendation (deterministic):** Blocked pending user input on OQ-1/OQ-2/OQ-3 (single batched escalation); all other findings resolve to synthesis inputs. No re-engagement handoffs required — specialist outputs converge with no disputes surviving aggregation.
+
+## R2: User escalation (batched OQ-1/OQ-2/OQ-3)
+
+- **Specialists engaged:** none — direct user escalation with recommendations, per Step 6.
+- **New input provided:** Joel's answers to the three surviving Open Questions.
+- **Claim ledger:** no new claims; three resolutions:
+  - OQ-1 → `:hardened` deprecated in 0.6.0, **removed at 1.0.0**. Docs state "deprecated in 0.6.0, removed in 1.0.0".
+  - OQ-2 → **PolicyConflict dropped entirely** (no class, no validation). Joel: "Since we're defaulting to frozen and allowing workers to opt out to something more permissive, we don't have a PolicyConflict... nothing to raise means no class, and we'll revisit later if we need to refine this." Reopening trigger: a strict-Gang feature (§11.4) that can forbid worker-level loosening.
+  - OQ-3 → seven-page wiki set approved as proposed (Home, Handoff-Policies, Coding-Idioms-Under-Frozen, Migration-Guide-0.6, Testing-Workers, Worker-Types, Performance); README keeps the quick tour and links into the wiki.
+- **Open Questions raised:** none.
+- **Spec-maturity tags:** n/a (no new findings).
+- **Resolution source:** OQ-1, OQ-2, OQ-3 — user input (verbatim above).
+- **Decisions produced:** D-6 (PolicyConflict dropped), D-9 (:hardened removed at 1.0.0), D-15 (seven-page wiki set).
+- **Changed in plan:** Implementation Approach; Decomposition and Sequencing (PR 2 PolicyConflict removed, PR 4 wiki set); Deferred (YAGNI); Definition of Done.
+- **Next-step recommendation (deterministic):** Go to synthesis — zero unresolved Open Questions, zero pending handoffs, round produced no new findings.

--- a/docs/planning/feature-implementation-plan.md
+++ b/docs/planning/feature-implementation-plan.md
@@ -1,0 +1,191 @@
+# Feature Implementation Plan: Handoff Immutability Policies
+
+<!-- Ship the three-policy handoff model (`:frozen` default, `:isolated`, `:shared`) plus diagnostics, a test harness, topology `#freeze!`, and migration docs as shifty 0.6.0, across four reviewed PRs (one per spec phase) branched from main; the plan ends at a built gem and release prep, which Joel publishes himself. -->
+
+## Source Specification
+
+- **Feature specification:** [handoff-immutability-policies.md](../handoff-immutability-policies.md)
+- **Specification decision log:** none — the spec came directly from the maintainer and has no plan-a-feature companions (no decision-log, team-findings, or feature-technical-notes files). The planning iteration artifacts for this implementation live in [artifacts/](artifacts/): [implementation-decision-log.md](artifacts/implementation-decision-log.md) and [implementation-iteration-history.md](artifacts/implementation-iteration-history.md), with verbatim specialist outputs in [artifacts/.round1-specialist-outputs.md](artifacts/.round1-specialist-outputs.md).
+- **Specification open items this plan resolves:** §8.3 shareable? fast path (deferred), §11.4 strict-Gang / PolicyConflict (dropped), §11.5 Shifty::Value mixin (deferred), §11.7 Ruby floor (3.2).
+
+## Outcome
+
+When this plan is executed, shifty 0.6.0 exists as a built gem in which every value crossing a worker boundary is governed by a handoff policy — `:frozen` by default (deeply frozen, zero-copy), with `:isolated` (private deep copy) and `:shared` (raw reference) opt-outs declarable at worker, pipeline, and global levels. Policy violations raise `Shifty::PolicyViolation` naming the offending worker; uncopyable values raise `Shifty::UnshareableValue`. A `Shifty::Testing` harness and opt-in RSpec sugar let unit tests exercise workers under production policy. Assembled pipelines can be locked with `#freeze!`. The gem's own DSL (`trailing_worker`, `side_worker`) works under the new default, the CI matrix and Ruby floor match the shipped behavior, and a seven-page wiki plus a slimmed README document it.
+
+## Context
+
+- **Driving constraint:** A committed 0.6.0 release that carries a breaking default-behavior change (`:shared` → `:frozen`). The change is the point of the release; it must land coherently with migration docs before Joel publishes.
+- **Stakeholders:** Joel (maintainer — owns the API, reviews each PR, builds and publishes the gem); existing shifty users (must migrate mutation-heavy tasks; served by loud/local errors and a migration guide); future contributors (served by the ingress-seam design keeping enforcement in one place).
+- **Future-state concern:** The `:frozen` default rests on the §8.2 amortization claim, which is unvalidated until PR-3 benchmarks; and the IO/`make_shareable` behavior is verified only on Ruby 4.0.5, re-verified on the 3.2 CI floor in a PR-1 spike. Both are tracked risks (see RAID Log).
+- **Out-of-scope boundary:** Static typing (Sorbet/RBS), Ractor-based parallel workers, persistent-data-structure dependencies, and enforcing purity of closure state — all per spec §12. Terminal (post-last-worker) output is deliberately un-governed ([D-12](artifacts/implementation-decision-log.md#d-12-terminal-output-governance-out-of-scope)).
+
+## Team Composition and Participation
+
+Medium team; deterministic aggregation was used in place of live PM facilitation (the spec-maturity gate never tripped). Full round detail: [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md).
+
+| Specialist | Status | Key Input |
+|------------|--------|-----------|
+| `project-manager` | Coordinator | Synthesized this plan; classified decisions; ran the YAGNI gate. |
+| `software-architect` | Active | Ingress-seam design, Policy module, precedence, error hierarchy, testing layering (A1–A7). |
+| `concurrency-analyst` | Active | Handoff-site correctness; empirically refuted the spec's `make_shareable` IO claims; trailing_worker aliasing; `#freeze!` mechanics (F1–F22). |
+| `test-engineer` | Active | Prioritized equivalence-class test plan, failure-set spike, existing-spec migration (8 cells + boundaries + meta-tests). |
+| `junior-developer` | Reframer | 0.x version translation, CI/gemspec gaps, benchmark home, wiki split, PolicyConflict vacuity (F1–F13). |
+| `information-architect` | Handoff (PR 4) | Not yet engaged; consult during wiki authoring (see Specialist Handoffs). |
+
+## Implementation Approach
+
+### Architecture and Integration Points
+
+Policy is enforced at the **consuming worker's intake**, not the producer's egress ([D-1](artifacts/implementation-decision-log.md#d-1-ingress-seam-enforcement-via-policysupply-decorator)). A single `intake(value)` seam wraps the primary pull at `worker.rb:64`, and a thin `PolicySupply` decorator (responding to `#shift` as `intake(supply.shift)`) is substituted as the task's 2nd argument at `worker.rb:66`. This covers all four `supply.shift` read sites (worker.rb:64; dsl.rb:55 filter, dsl.rb:86 batch, dsl.rb:122 trailing) with zero dsl.rb task-body changes; producer-side `handoff`/`Fiber.yield` sites need no instrumentation because every yielded value surfaces at a consumer's pull ([D-1](artifacts/implementation-decision-log.md#d-1-ingress-seam-enforcement-via-policysupply-decorator)). The `intake`/`perform_task`/`policy_supply` sketch is in [artifacts/.round1-specialist-outputs.md](artifacts/.round1-specialist-outputs.md) (A1) and is not inlined here.
+
+New files land as: **PR 1** — `lib/shifty/errors.rb`, `lib/shifty/policy.rb`, `lib/shifty/configuration.rb`; **PR 2** — `lib/shifty/testing.rb`, `lib/shifty/rspec.rb`. `lib/shifty.rb` requires the runtime files; `shifty/testing` and `shifty/rspec` are separate opt-in requires, neither loaded by `require "shifty"` ([D-18](artifacts/implementation-decision-log.md#trivial-decisions)).
+
+Errors consolidate into `lib/shifty/errors.rb` under a `Shifty::Error` base with a `PolicyError` intermediate; `PolicyViolation` and `UnshareableValue` descend from it, and existing `WorkerError`/`WorkerInitializationError` are reparented source-compatibly ([D-5](artifacts/implementation-decision-log.md#d-5-consolidated-error-hierarchy)). No `PolicyConflict` class ships ([D-6](artifacts/implementation-decision-log.md#d-6-policyconflict-dropped-entirely)).
+
+### Policy module and diagnostics
+
+`Shifty::Policy` is a module of three frozen singleton lambdas (`Frozen`, `Isolated`, `Shared`) behind `Policy.resolve(name)`, with `ALIASES = {hardened: :isolated}` and a `canonical` step that emits the `:hardened` deprecation warning — not a class hierarchy, not a mixin ([D-3](artifacts/implementation-decision-log.md#d-3-policy-as-three-frozen-singletons)). Workers gain an optional `name:` used purely in diagnostics ([D-14](artifacts/implementation-decision-log.md#trivial-decisions)). `PolicyViolation` carries worker/policy/receiver/value/cause and uses the `receiver.equal?(value)` / reachable / unrelated heuristic (§6.2) to attribute the mutation.
+
+### Precedence and configuration
+
+Precedence (worker > pipeline > global, §5.2) is two nullable Worker attributes — `@policy` (contract) and `@pipeline_policy` (default) — resolved by `@policy || @pipeline_policy || Shifty.config.default_policy` and memoized ([D-4](artifacts/implementation-decision-log.md#d-4-two-attribute-policy-precedence)). Because bare `|` chains have no chain object (a pipeline is just the last worker), `.with_policy` walks the `.supply` chain upstream, and Gang fans out across its roster ([D-4](artifacts/implementation-decision-log.md#d-4-two-attribute-policy-precedence)). Global config is a `Shifty::Configuration` object with `default_policy` (built-in `:frozen`) plus `Shifty.configure`/`config`/`reset_configuration!` ([D-19](artifacts/implementation-decision-log.md#trivial-decisions)).
+
+### Runtime behavior and IO detection
+
+At each intake the effective policy is applied: `:frozen` calls `Ractor.make_shareable`, `:isolated` copies (`make_shareable(copy: true)`, Marshal fallback), `:shared` passes through. Crucially, IO-like values are detected **proactively** and raise `UnshareableValue` *before* `make_shareable` is called ([D-2](artifacts/implementation-decision-log.md#d-2-proactive-io-detection-for-unshareablevalue)): the spec's claim that `make_shareable` rejects IO is empirically wrong — it silently freezes live IO process-wide, and `copy: true` leaks a file descriptor. Proc and `Enumerator::Lazy` raise naturally and are wrapped. The shipped `trailing_worker` is fixed in PR 1 to hand off `trail.dup` rather than its live closure array ([D-7](artifacts/implementation-decision-log.md#d-7-trailing_worker-aliasing-fix-in-phase-1)); batch/splitter/filter workers are confirmed safe and left untouched. Terminal output (the last worker's return to user code) is un-governed by design ([D-12](artifacts/implementation-decision-log.md#d-12-terminal-output-governance-out-of-scope)).
+
+`#freeze!` (PR 3) locks assembled topology; its motivation is `supply=`/Roster rewiring, not the non-existent `Worker#task=` the spec cites. It must (a) force-materialize each worker's lazy default task before freezing, (b) freeze the Roster `@workers` array, and (c) for bare `|` chains, walk the `.supply` chain to discover members (F19–F21).
+
+### Testing layering and the empirical spike
+
+`shifty/testing` (pure Ruby) provides `Shifty::Testing.run(worker, inputs:, policy:)` and the `mutates_input?` detector; `shifty/rspec` provides the `"a policy-safe worker"` shared example and the `mutate_input` matcher, both thin wrappers over the detector ([D-21](artifacts/implementation-decision-log.md#trivial-decisions)). Because the `:isolated`/`:frozen` failure sets diverge from the spec's stated behavior, the failure-set table must be **spiked on the target Ruby before its spec is authored** ([D-2](artifacts/implementation-decision-log.md#d-2-proactive-io-detection-for-unshareablevalue), [D-13](artifacts/implementation-decision-log.md#d-13-equivalence-class-test-matrix)).
+
+## Decomposition and Sequencing
+
+Four PRs, one per spec phase, each branched from main and reviewed before merge. Each PR's definition of done includes `standardrb` clean and the full RSpec suite green.
+
+| # | Work Unit (PR) | Delivers | Depends On | Verification |
+|---|-----------|----------|------------|--------------|
+| 1 | **Phase 1 — mechanism** | Ingress seam + `PolicySupply` ([D-1](artifacts/implementation-decision-log.md#d-1-ingress-seam-enforcement-via-policysupply-decorator)); `Policy` module ([D-3](artifacts/implementation-decision-log.md#d-3-policy-as-three-frozen-singletons)); precedence + `.with_policy` ([D-4](artifacts/implementation-decision-log.md#d-4-two-attribute-policy-precedence)); `errors.rb` ([D-5](artifacts/implementation-decision-log.md#d-5-consolidated-error-hierarchy)); global config ([D-19](artifacts/implementation-decision-log.md#trivial-decisions)); proactive IO detection + PR-1 spike ([D-2](artifacts/implementation-decision-log.md#d-2-proactive-io-detection-for-unshareablevalue)); `trailing_worker` fix + `side_worker` `mode:`/`policy:` shim ([D-7](artifacts/implementation-decision-log.md#d-7-trailing_worker-aliasing-fix-in-phase-1), [D-20](artifacts/implementation-decision-log.md#trivial-decisions)); **`required_ruby_version >= 3.2` + CI matrix rewrite + codeclimate removal** ([D-8](artifacts/implementation-decision-log.md#d-8-ruby-32-floor-and-ci-matrix-in-phase-1), [D-16](artifacts/implementation-decision-log.md#trivial-decisions)) | — | Policy × shape cells 1–8, boundary 9–13, failure-set table #19 (post-spike), migration specs #24–26; suite green on 3.2/3.3/3.4 |
+| 2 | **Phase 2 — diagnostics & testing** | Mutation detector; `Shifty::Testing.run`; RSpec shared example + `mutate_input` matcher ([D-21](artifacts/implementation-decision-log.md#trivial-decisions)); separate requires ([D-18](artifacts/implementation-decision-log.md#trivial-decisions)). **No `PolicyConflict`** ([D-6](artifacts/implementation-decision-log.md#d-6-policyconflict-dropped-entirely)) | 1 | Error-diagnostic tests #14–17; meta-tests #20–23 |
+| 3 | **Phase 3 — performance & `#freeze!`** | `benchmark/` dir + `benchmark-ips` dev dep, manual-run ([D-10](artifacts/implementation-decision-log.md#d-10-manual-run-benchmark-directory)); `#freeze!` with F19–F21 scope | 1 | Benchmark results captured; `#freeze!` specs (lazy-task materialize, roster freeze, supply-chain walk) |
+| 4 | **Phase 4 — release** | Version bump → 0.6.0 + CHANGELOG ([D-11](artifacts/implementation-decision-log.md#d-11-version-bump-and-changelog-in-phase-4-pr)); README rewrite + seven wiki drafts ([D-15](artifacts/implementation-decision-log.md#trivial-decisions)); PR-26 doc reconciliation (README Concurrency Model, docs/use_cases.md, worker.rb comments); spec-text correction for IO ([D-2](artifacts/implementation-decision-log.md#d-2-proactive-io-detection-for-unshareablevalue)); repo sweep ([D-22](artifacts/implementation-decision-log.md#trivial-decisions)); gem build | 1, 2, 3 | Docs consistent (planned → shipped); benchmark results published to wiki Performance page; `gem build` succeeds |
+
+## RAID Log
+
+### Risks
+
+| ID | Risk | Likelihood | Severity | Blast Radius | Reversibility | Owner | Mitigation |
+|----|------|------------|----------|--------------|---------------|-------|------------|
+| R1 | §8.2 amortization claim is unvalidated until PR-3 benchmarks; if `:frozen` cost is not delta-proportional on real value shapes, the default choice is wrong | Low | High | The headline default of the release | Reversible pre-release (change default) | junior-developer / Joel | Benchmarks in PR 3 ([D-10](artifacts/implementation-decision-log.md#d-10-manual-run-benchmark-directory)); if contradicted, revisit default before 0.6.0 ships |
+| R2 | `make_shareable`/IO behavior verified only on Ruby 4.0.5, not the 3.2 floor | Medium | Medium | IO-detection predicate + `:isolated` failure-set table | Reversible (adjust predicate) | concurrency-analyst | PR-1 spike re-verifies on 3.2 CI before the failure-set spec is authored ([D-2](artifacts/implementation-decision-log.md#d-2-proactive-io-detection-for-unshareablevalue), [D-8](artifacts/implementation-decision-log.md#d-8-ruby-32-floor-and-ci-matrix-in-phase-1)) |
+| R3 | Breaking the default (`:shared` → `:frozen`) surprises every mutation-heavy task | High (that it fires) | Low (well-behaved) | All existing user pipelines | Reversible per-worker/global (`:shared`) | Joel | Loud/local `PolicyViolation`; migration guide with four ordered paths; blanket opt-out documented; small user base |
+
+### Assumptions
+
+| ID | Assumption | What Changes If Wrong | Verifier | Status |
+|----|------------|-----------------------|----------|--------|
+| A1 | Every value crossing a boundary surfaces through some consumer's `supply.shift` (so intake enforcement is complete) | Producer-side sites would need instrumentation | concurrency-analyst F1–F4 | Verified (F1–F4, four sites enumerated) |
+| A2 | `make_shareable(copy: true)` short-circuits (returns same object) for already-frozen Data | `:frozen`→`:isolated` steady-state cost model changes | concurrency-analyst F11 | Verified (F11, structural) — CPU amortization still Runtime-only (R1) |
+| A3 | `main` may carry shipped-but-unreleased behavior between phase PRs | Would force per-PR version bumps | junior-developer F5 | Verified (nothing publishes until Joel builds 0.6.0) |
+
+### Issues
+
+| ID | Issue | Owner | Next Step |
+|----|-------|-------|-----------|
+| I1 | Spec §3.3/§10.1 text asserts `make_shareable` rejects IO — factually wrong; ships as-is until PR 4 | PM / Joel | Correct spec + README/wiki text in PR 4 ([D-2](artifacts/implementation-decision-log.md#d-2-proactive-io-detection-for-unshareablevalue)) |
+
+### Dependencies
+
+| ID | Dependency | Owner | Status |
+|----|------------|-------|--------|
+| Dep1 | `benchmark-ips` dev dependency (PR 3) | junior-developer | Not yet added |
+| Dep2 | GitHub wiki repo exists to receive `docs/wiki/` drafts (PR 4) | Joel | To confirm at PR 4 |
+
+## Testing Strategy
+
+Sourced from test-engineer's prioritized plan ([D-13](artifacts/implementation-decision-log.md#d-13-equivalence-class-test-matrix)); rspec-given Given/When/Then house style, `raise_error(/regex/)` plus structured accessor checks, real values, no doubles ([D-17](artifacts/implementation-decision-log.md#trivial-decisions)).
+
+- **Observable behaviors to test:**
+  - **8 equivalence-class cells:** `:frozen`×Array (`<<` raises, `receiver.equal?(value)`); `:frozen`×Hash-containing-Array (nested mutation raises, receiver reachable-not-equal); `:frozen`×Data (`.with` returns new frozen instance); `:frozen`×nil (passthrough); `:isolated`×Array (copy mutates freely, upstream unaffected); `:isolated`×Data-with-mutable-member; `:shared`×Array (mutation visible to holders); `:shared`×IO (passes through, no error).
+  - **Boundary cases 9–13:** mid-task `supply.shift` under upstream `:frozen` raises like primary intake (#9); splitter under `:frozen` freezes *each* yielded part, not just the last (#10, deliberately fails a naive single-site impl); `trailing_worker` under `:frozen` must not raise + prior trail unaffected (#11, proves `trail.dup`); `side_worker(policy: :isolated)` original unmutated (#12); criteria-bypass value still policy-applied (#13).
+  - **Error diagnostics 14–17:** `PolicyViolation` accessors + message (#14); receiver heuristic three branches — equal / reachable / unrelated (#15); `UnshareableValue` guidance text matches `/:shared/` (#16); `violation.cause` is the original `FrozenError` (#17).
+  - **Shim & failure sets 18–19:** `:hardened`→`:isolated` equivalence + one-time deprecation warning (capture `$stderr`, no ActiveSupport) (#18); table-driven `:isolated` failure set over IO/Proc/Lazy/singleton — **authored only after the PR-1 spike** (#19, [D-2](artifacts/implementation-decision-log.md#d-2-proactive-io-detection-for-unshareablevalue)).
+  - **Meta-tests 20–23:** `Testing.run` uses the worker's effective policy by default (#20); explicit `policy:` override (#21); `mutate_input` matcher passes/fails against real workers (#22); shared example passes known-good/fails known-bad (#23).
+- **Existing-suite migration (#24–26):** dsl_spec.rb:149–164 (`v << :boo`) rewritten non-destructively + a companion `policy: :shared` spec preserving old behavior (the migration worked example); dsl_spec.rb:166–174 `:hardened` context retargeted to `:isolated` with a thin shim regression; dsl_spec.rb:317–341 trailing_worker passes once `trail.dup` lands, plus a new aliasing assertion. worker/gang/roster specs are mutation-free and pass unmodified.
+- **Test doubles posture:** none for policy behavior — assert on real frozen/copied values and raised errors, not on `make_shareable` invocation ([D-17](artifacts/implementation-decision-log.md#trivial-decisions)).
+- **Test levels:** unit (policy cells, diagnostics, DSL workers), integration (framework-run harness meta-tests), migration (existing-spec rewrites doubling as worked examples).
+- **Skipped with triggers:** nil×isolated/shared, String cells (same class as Array), full cartesian, identity-keyed-cache caveat, shareable? fast path, PolicyConflict tests — all per [D-13](artifacts/implementation-decision-log.md#d-13-equivalence-class-test-matrix) / Deferred.
+
+## Definition of Done
+
+- [ ] Every value crossing a worker boundary is policy-governed at intake; `:frozen` is the built-in default ([D-1](artifacts/implementation-decision-log.md#d-1-ingress-seam-enforcement-via-policysupply-decorator), [D-19](artifacts/implementation-decision-log.md#trivial-decisions)).
+- [ ] Mutation under `:frozen` raises `PolicyViolation` naming the worker; IO under `:frozen`/`:isolated` raises `UnshareableValue` without freezing live handles ([D-2](artifacts/implementation-decision-log.md#d-2-proactive-io-detection-for-unshareablevalue)).
+- [ ] Policy declarable at worker/pipeline/global with worker > pipeline > global precedence ([D-4](artifacts/implementation-decision-log.md#d-4-two-attribute-policy-precedence)).
+- [ ] Shipped DSL works under `:frozen`: trailing_worker fixed, side_worker `:hardened` shim warns once ([D-7](artifacts/implementation-decision-log.md#d-7-trailing_worker-aliasing-fix-in-phase-1), [D-20](artifacts/implementation-decision-log.md#trivial-decisions), [D-9](artifacts/implementation-decision-log.md#d-9-hardened-deprecation-horizon)).
+- [ ] `Shifty::Testing.run`, `mutate_input` matcher, and `"a policy-safe worker"` shared example ship as opt-in requires ([D-18](artifacts/implementation-decision-log.md#trivial-decisions), [D-21](artifacts/implementation-decision-log.md#trivial-decisions)).
+- [ ] `#freeze!` locks topology (lazy-task materialize, roster freeze, supply-chain walk).
+- [ ] Benchmarks run and published; §8.2 amortization confirmed or the default revisited ([D-10](artifacts/implementation-decision-log.md#d-10-manual-run-benchmark-directory)).
+- [ ] CI green on 3.2/3.3/3.4; gemspec floor `>= 3.2`; codeclimate dep removed ([D-8](artifacts/implementation-decision-log.md#d-8-ruby-32-floor-and-ci-matrix-in-phase-1), [D-16](artifacts/implementation-decision-log.md#trivial-decisions)).
+- [ ] Version bumped to 0.6.0, CHANGELOG written, README slimmed, seven wiki pages drafted, PR-26 docs reconciled ([D-11](artifacts/implementation-decision-log.md#d-11-version-bump-and-changelog-in-phase-4-pr), [D-15](artifacts/implementation-decision-log.md#trivial-decisions)).
+- [ ] `standardrb` clean and full suite green on each PR; gem builds. Post-ship owner: Joel (publishes with 2FA).
+
+## Specialist Handoffs for Implementation
+
+- **`information-architect`** — dispatch during PR 4 wiki authoring; needs the seven approved page titles ([D-15](artifacts/implementation-decision-log.md#trivial-decisions)), the coding-idioms table (§7), and the migration paths (§10) to structure findability and progressive disclosure across Home/Handoff-Policies/Coding-Idioms/Migration/Testing/Worker-Types/Performance.
+- **`han` code review** — dispatch per PR before merge; needs the PR diff and this plan's Definition-of-Done row for that phase.
+- **`concurrency-analyst`** — dispatch for the PR-1 spike to re-verify `make_shareable`/IO behavior on Ruby 3.2 before the failure-set spec (#19) is authored; needs the 3.2 CI environment ([D-2](artifacts/implementation-decision-log.md#d-2-proactive-io-detection-for-unshareablevalue)).
+
+## Deferred (YAGNI)
+
+### PolicyConflict class + build-time validation
+- **Why deferred:** Dropped by user (R2) — with worker-declarations authoritative and pipeline policy default-only, no violable rule exists to raise; a class with no raiser is dead code future agents would copy ([D-6](artifacts/implementation-decision-log.md#d-6-policyconflict-dropped-entirely)).
+- **Reopen when:** A strict-Gang feature (§11.4) that lets a pipeline forbid worker-level loosening.
+- **Source:** software-architect A4 / junior-developer C11; decided by Joel, R2.
+
+### `shareable?` fast path / `:isolated_frozen` variant (§8.3)
+- **Why deferred:** Committed decision (option b) for contract simplicity; premature optimization with no measured copy-cost evidence.
+- **Reopen when:** §8.4 benchmarks show material copy cost that the fast path would remove.
+- **Source:** spec §8.3; software-architect Deferred list.
+
+### `Shifty::Value` mixin (§11.5)
+- **Why deferred:** The spec itself recommends staying unopinionated; single speculative abstraction with no concrete demand.
+- **Reopen when:** An official work-item envelope feature (provenance/batch metadata) lands, making `Data` the substrate.
+- **Source:** spec §11.5; software-architect Deferred list.
+
+### Fiber-local "current worker" registry (concurrency F6)
+- **Why deferred:** `self` is available everywhere the registry would be consulted; abstraction with no use.
+- **Reopen when:** Task bodies need self-introspection beyond what `self` provides.
+- **Source:** concurrency-analyst F6.
+
+### `Shifty::TopologyFrozenError` wrapper (F22)
+- **Why deferred:** Plain `FrozenError` from post-`freeze!` `supply=` is already unambiguous; a wrapper adds a class for no clarity gain.
+- **Reopen when:** Migration feedback shows users are confused by the raw `FrozenError`.
+- **Source:** concurrency-analyst F22.
+
+### Full 3×10 policy × value-shape cartesian
+- **Why deferred:** Replaced by 8 equivalence-class cells — String duplicates Array, nil cells are trivial passthrough; simpler version satisfies the same evidence ([D-13](artifacts/implementation-decision-log.md#d-13-equivalence-class-test-matrix)).
+- **Reopen when:** A value shape with distinct freeze/copy behavior outside the existing classes appears.
+- **Source:** test-engineer.
+
+### CI-run benchmarks
+- **Why deferred:** Replaced by a manual-run `benchmark/` directory with results published to the wiki — CI runs would be slow/flaky for an occasionally-consulted measurement; simpler version satisfies the same evidence ([D-10](artifacts/implementation-decision-log.md#d-10-manual-run-benchmark-directory)).
+- **Reopen when:** A performance regression that only continuous measurement would catch becomes a real concern.
+- **Source:** junior-developer C19 / OQ-6.
+
+## Open Items
+
+None blocking. All seven R1 Open Questions resolved (OQ-4/5/6/7 by evidence-aggregation; OQ-1/2/3 by Joel in R2). The plan ends at a built gem and release prep; Joel publishes 0.6.0 himself with 2FA — publication is deliberately outside this plan's scope, not an unresolved item.
+
+## Summary
+
+- **Outcome delivered:** shifty 0.6.0, built and release-ready, with `:frozen`-default handoff immutability, diagnostics, a test harness, topology freeze, and migration docs, across four reviewed PRs.
+- **Team size:** 5 specialists (PM, software-architect, concurrency-analyst, test-engineer, junior-developer; information-architect on PR-4 handoff) — see [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
+- **Rounds of facilitation:** 2 — see [artifacts/implementation-iteration-history.md](artifacts/implementation-iteration-history.md)
+- **Decisions committed:** 22 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Decisions settled by evidence:** 15 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Decisions settled by junior-developer reframing:** 1 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Decisions settled by user input:** 6 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Rejected alternatives recorded:** 24 — see [artifacts/implementation-decision-log.md](artifacts/implementation-decision-log.md)
+- **Open items remaining:** 0 blocking
+- **Recommendation:** Ship as planned — begin PR 1 (mechanism + Ruby 3.2 floor + PR-1 IO spike).

--- a/lib/shifty.rb
+++ b/lib/shifty.rb
@@ -1,4 +1,7 @@
 require_relative "shifty/version"
+require_relative "shifty/errors"
+require_relative "shifty/configuration"
+require_relative "shifty/policy"
 require_relative "shifty/worker"
 require_relative "shifty/gang"
 require_relative "shifty/roster"

--- a/lib/shifty/configuration.rb
+++ b/lib/shifty/configuration.rb
@@ -1,9 +1,13 @@
 module Shifty
   class Configuration
-    attr_accessor :default_policy
+    attr_reader :default_policy
 
     def initialize
       @default_policy = :frozen
+    end
+
+    def default_policy=(policy_name)
+      @default_policy = Policy.validate!(policy_name)
     end
   end
 

--- a/lib/shifty/configuration.rb
+++ b/lib/shifty/configuration.rb
@@ -1,0 +1,23 @@
+module Shifty
+  class Configuration
+    attr_accessor :default_policy
+
+    def initialize
+      @default_policy = :frozen
+    end
+  end
+
+  class << self
+    def config
+      @config ||= Configuration.new
+    end
+
+    def configure
+      yield config
+    end
+
+    def reset_configuration!
+      @config = Configuration.new
+    end
+  end
+end

--- a/lib/shifty/dsl.rb
+++ b/lib/shifty/dsl.rb
@@ -1,6 +1,4 @@
 module Shifty
-  class WorkerInitializationError < StandardError; end
-
   module DSL
     def source_worker(argument = nil, &block)
       ensure_correct_arity_for!(argument, block)
@@ -32,17 +30,24 @@ module Shifty
     def side_worker(options = {}, &block)
       options[:tags] ||= []
       options[:tags] << :side_effect
-      mode = options[:mode] || :normal
+      options[:policy] = :hardened if options.delete(:mode) == :hardened
       ensure_regular_arity!(block)
 
-      Worker.new(options) do |value|
+      # The block must ask the worker for its policy at shift time, so the
+      # local is captured by the closure before it is assigned. Not redundant.
+      worker = nil
+      worker = Worker.new(options) do |value| # standard:disable Style/RedundantAssignment
         value.tap do |v|
-          used_value = (mode == :hardened) ?
+          next unless v
+          # Under :isolated the block observes a private scratch copy, so
+          # its mutations evaporate and the untouched value flows on.
+          used_value = (worker.effective_policy == :isolated) ?
             Marshal.load(Marshal.dump(v)) : v
 
-          v && block.call(used_value)
+          block.call(used_value)
         end
       end
+      worker
     end
 
     def filter_worker(options = {}, &block)
@@ -122,7 +127,10 @@ module Shifty
             trail.unshift supply.shift
           end
 
-          trail
+          # Hand off a snapshot: the builder keeps mutating `trail` across
+          # calls, and a downstream :frozen intake would freeze the live
+          # closure array in place.
+          trail.dup
         else
           value # hint: it's nil!
         end

--- a/lib/shifty/dsl.rb
+++ b/lib/shifty/dsl.rb
@@ -30,7 +30,7 @@ module Shifty
     def side_worker(options = {}, &block)
       options[:tags] ||= []
       options[:tags] << :side_effect
-      options[:policy] = :hardened if options.delete(:mode) == :hardened
+      deprecate_mode_option!(options)
       ensure_regular_arity!(block)
 
       # The block must ask the worker for its policy at shift time, so the
@@ -42,7 +42,7 @@ module Shifty
           # Under :isolated the block observes a private scratch copy, so
           # its mutations evaporate and the untouched value flows on.
           used_value = (worker.effective_policy == :isolated) ?
-            Marshal.load(Marshal.dump(v)) : v
+            Policy::Isolated.call(v, worker: worker) : v
 
           block.call(used_value)
         end
@@ -142,6 +142,19 @@ module Shifty
     end
 
     private
+
+    def deprecate_mode_option!(options)
+      return unless options.key?(:mode)
+      mode = options.delete(:mode)
+      if mode == :hardened
+        warn "[shifty] side_worker mode: :hardened is deprecated and will be " \
+             "removed in 1.0.0; use policy: :isolated instead."
+        options[:policy] ||= :isolated
+      else
+        warn "[shifty] side_worker's mode: option is deprecated and ignored " \
+             "(received mode: #{mode.inspect}); declare a policy: instead."
+      end
+    end
 
     def throw_with(*msg)
       raise WorkerInitializationError.new([msg].flatten.join(" "))

--- a/lib/shifty/errors.rb
+++ b/lib/shifty/errors.rb
@@ -64,16 +64,27 @@ module Shifty
       end
     end
 
+    # Bounds the diagnostic graph walk; past this the heuristic gives up
+    # and reports the honest "inspect both to judge" fallback rather than
+    # risking a SystemStackError that would mask the violation itself.
+    MAX_REACHABILITY_NODES = 50_000
+
     def reachable_from_value?
-      reachable?(value, receiver, {}.compare_by_identity)
+      seen = {}.compare_by_identity
+      stack = [value]
+      until stack.empty?
+        node = stack.pop
+        next if node.nil? || seen[node]
+        return false if seen.size >= MAX_REACHABILITY_NODES
+        seen[node] = true
+        return true if node.equal?(receiver)
+        stack.concat(children_of(node))
+      end
+      false
     end
 
-    def reachable?(node, target, seen)
-      return false if node.nil? || seen[node]
-      seen[node] = true
-      return true if node.equal?(target)
-
-      children = case node
+    def children_of(node)
+      case node
       when Array then node
       when Hash then node.keys + node.values
       when Struct then node.to_a
@@ -81,7 +92,6 @@ module Shifty
         members = (node.respond_to?(:to_h) && node.is_a?(Data)) ? node.to_h.values : []
         members + node.instance_variables.map { |iv| node.instance_variable_get(iv) }
       end
-      children.any? { |child| reachable?(child, target, seen) }
     end
   end
 

--- a/lib/shifty/errors.rb
+++ b/lib/shifty/errors.rb
@@ -1,0 +1,109 @@
+module Shifty
+  class Error < StandardError; end
+
+  class WorkerError < Error; end
+
+  class WorkerInitializationError < Error; end
+
+  class PolicyError < Error
+    attr_reader :worker, :policy, :value
+
+    def cause
+      @wrapped_cause || super
+    end
+
+    private
+
+    def worker_label
+      label = (worker.respond_to?(:name) && worker.name) ? "`#{worker.name}`" : "(unnamed)"
+      tags = worker.respond_to?(:tags) ? worker.tags : []
+      tags&.any? ? "#{label} (tags: #{tags.inspect})" : label
+    end
+  end
+
+  # Raised when a task mutates a value it received under a policy that
+  # forbids mutation. Wraps the original FrozenError (never masks it) and
+  # names the worker, the effective policy, and the object the task tried
+  # to mutate, with a heuristic locating that object relative to the
+  # handed-off value.
+  class PolicyViolation < PolicyError
+    attr_reader :receiver
+
+    def initialize(worker:, policy:, receiver:, value:, cause:)
+      @worker = worker
+      @policy = policy
+      @receiver = receiver
+      @value = value
+      @wrapped_cause = cause
+      super(build_message)
+    end
+
+    private
+
+    def build_message
+      <<~MSG
+        Worker #{worker_label} received its value under the #{policy.inspect} handoff \
+        policy, and its task attempted to mutate #{receiver_description}.
+
+        Either make the task non-destructive — e.g. `map` instead of `map!`, \
+        `value.with(...)`, `arr + [x]`, `hash.merge(...)` — or declare a different \
+        policy on this worker: `policy: :isolated` (task works on a private scratch \
+        copy) or `policy: :shared` (raw reference; no protection).
+      MSG
+    end
+
+    def receiver_description
+      if receiver.equal?(value)
+        "an instance of #{receiver.class} — the handed-off value itself"
+      elsif reachable_from_value?
+        "an instance of #{receiver.class} reachable from the handed-off value"
+      else
+        "an instance of #{receiver.class} (#{receiver.inspect[0, 80]}), which may be " \
+          "unrelated to the handed-off value (an instance of #{value.class}); " \
+          "inspect both to judge"
+      end
+    end
+
+    def reachable_from_value?
+      reachable?(value, receiver, {}.compare_by_identity)
+    end
+
+    def reachable?(node, target, seen)
+      return false if node.nil? || seen[node]
+      seen[node] = true
+      return true if node.equal?(target)
+
+      children = case node
+      when Array then node
+      when Hash then node.keys + node.values
+      when Struct then node.to_a
+      else
+        members = (node.respond_to?(:to_h) && node.is_a?(Data)) ? node.to_h.values : []
+        members + node.instance_variables.map { |iv| node.instance_variable_get(iv) }
+      end
+      children.any? { |child| reachable?(child, target, seen) }
+    end
+  end
+
+  # Raised at the handoff itself when a value cannot cross the boundary
+  # under the effective policy (cannot be frozen or deep-copied).
+  class UnshareableValue < PolicyError
+    def initialize(worker:, policy:, value:, cause: nil)
+      @worker = worker
+      @policy = policy
+      @value = value
+      @wrapped_cause = cause
+      super(build_message)
+    end
+
+    private
+
+    def build_message
+      "Worker #{worker_label} received a value (an instance of #{value.class}) " \
+        "that cannot cross the handoff boundary under the #{policy.inspect} policy: " \
+        "it cannot be #{(policy == :isolated) ? "deep-copied" : "frozen"}. " \
+        "Declare `policy: :shared` on this worker (raw pass-by-reference), " \
+        "or restructure the value."
+    end
+  end
+end

--- a/lib/shifty/gang.rb
+++ b/lib/shifty/gang.rb
@@ -6,11 +6,17 @@ module Shifty
     attr_reader :roster, :tags
 
     include Taggable
+    include PolicyDeclarable
 
     def initialize(workers = [], p = {})
       @roster = Roster.new(workers)
       self.criteria = p[:criteria]
       self.tags     = p[:tags]
+      self.pipeline_policy = Policy.canonical(p[:policy]) if p[:policy]
+    end
+
+    def pipeline_policy=(policy_name)
+      roster.workers.each { |w| w.pipeline_policy = policy_name }
     end
 
     def shift

--- a/lib/shifty/gang.rb
+++ b/lib/shifty/gang.rb
@@ -12,18 +12,25 @@ module Shifty
       @roster = Roster.new(workers)
       self.criteria = p[:criteria]
       self.tags     = p[:tags]
-      self.pipeline_policy = Policy.canonical(p[:policy]) if p[:policy]
+      self.pipeline_policy = Policy.validate!(p[:policy]) if p[:policy]
     end
 
     def pipeline_policy=(policy_name)
+      # Persisted so workers appended after the declaration inherit it.
+      @pipeline_policy = policy_name
       roster.workers.each { |w| w.pipeline_policy = policy_name }
     end
+
+    attr_reader :pipeline_policy
 
     def shift
       if criteria_passes?
         roster.last.shift
       else
-        roster.first.supply.shift
+        # Even when the gang's criteria bypasses its workers, the value
+        # still crosses the gang's boundary — govern it with the entry
+        # worker's policy, matching Worker#shift's bypass behavior.
+        roster.first.intake(roster.first.supply.shift)
       end
     end
 
@@ -32,7 +39,7 @@ module Shifty
     end
 
     def supply
-      roster.first.supply
+      roster.first&.supply
     end
 
     def supply=(supplier)
@@ -47,6 +54,7 @@ module Shifty
 
     def append(worker)
       roster << worker
+      worker.pipeline_policy = pipeline_policy if pipeline_policy
     end
 
     class << self

--- a/lib/shifty/policy.rb
+++ b/lib/shifty/policy.rb
@@ -1,0 +1,91 @@
+module Shifty
+  # Shared by Worker and Gang: declares a pipeline-level policy default on
+  # every node reachable upstream through the supply chain. A worker's own
+  # policy declaration (its contract) always wins over the pipeline default.
+  module PolicyDeclarable
+    def with_policy(policy_name)
+      policy_name = Policy.canonical(policy_name)
+      Policy.resolve(policy_name)
+      node = self
+      while node.respond_to?(:pipeline_policy=)
+        node.pipeline_policy = policy_name
+        node = node.supply
+      end
+      self
+    end
+  end
+
+  # Handoff policies govern how a value crosses a worker boundary.
+  # Each policy responds to #call(value, worker:) and returns the value
+  # the worker's task will receive.
+  module Policy
+    # Deeply freezes the value in place (zero copies) so any mutation,
+    # anywhere in the pipeline, raises at the worker that attempted it.
+    # IO-like values are rejected proactively: Ractor.make_shareable would
+    # otherwise freeze a live handle in place — a process-wide side effect
+    # on shared resources like loggers or $stdout.
+    Frozen = lambda do |value, worker:|
+      if value.is_a?(IO)
+        raise UnshareableValue.new(worker: worker, policy: :frozen, value: value)
+      end
+      begin
+        Ractor.make_shareable(value)
+      rescue Ractor::Error => e
+        raise UnshareableValue.new(worker: worker, policy: :frozen, value: value, cause: e)
+      end
+    end
+
+    # Hands the task a private, mutable deep copy. Marshal is the mechanism
+    # because Ractor.make_shareable(copy: true) returns a *frozen* copy,
+    # which cannot satisfy the :isolated contract of a mutable scratch value.
+    Isolated = lambda do |value, worker:|
+      Marshal.load(Marshal.dump(value))
+    rescue TypeError => e
+      raise UnshareableValue.new(worker: worker, policy: :isolated, value: value, cause: e)
+    end
+
+    # The escape hatch: the raw reference passes through untouched.
+    Shared = ->(value, worker:) { value }
+
+    TABLE = {
+      frozen: Frozen,
+      isolated: Isolated,
+      shared: Shared
+    }.freeze
+
+    ALIASES = {hardened: :isolated}.freeze
+
+    class << self
+      def resolve(name)
+        TABLE.fetch(canonical(name)) do
+          raise ArgumentError, "unknown policy #{name.inspect}"
+        end
+      end
+
+      def canonical(name)
+        if ALIASES.key?(name)
+          replacement = ALIASES[name]
+          warn "[shifty] policy :#{name} is deprecated and will be " \
+               "removed in 1.0.0; use :#{replacement} instead."
+          replacement
+        else
+          name
+        end
+      end
+    end
+
+    # Wraps a worker's supply so that values the task pulls directly
+    # (e.g. filter/batch/trailing workers calling supply.shift mid-task)
+    # cross the boundary under the same policy as the primary intake.
+    class Supply
+      def initialize(supply, worker)
+        @supply = supply
+        @worker = worker
+      end
+
+      def shift
+        @worker.intake(@supply.shift)
+      end
+    end
+  end
+end

--- a/lib/shifty/policy.rb
+++ b/lib/shifty/policy.rb
@@ -4,10 +4,11 @@ module Shifty
   # policy declaration (its contract) always wins over the pipeline default.
   module PolicyDeclarable
     def with_policy(policy_name)
-      policy_name = Policy.canonical(policy_name)
-      Policy.resolve(policy_name)
+      policy_name = Policy.validate!(policy_name)
       node = self
-      while node.respond_to?(:pipeline_policy=)
+      seen = {}.compare_by_identity
+      while node.respond_to?(:pipeline_policy=) && !seen[node]
+        seen[node] = true
         node.pipeline_policy = policy_name
         node = node.supply
       end
@@ -70,6 +71,16 @@ module Shifty
           replacement
         else
           name
+        end
+      end
+
+      # Canonicalizes and validates a policy name at declaration time, so
+      # a typo fails where it was written rather than at first shift.
+      def validate!(name)
+        canonical(name).tap do |canonical_name|
+          unless TABLE.key?(canonical_name)
+            raise ArgumentError, "unknown policy #{name.inspect}"
+          end
         end
       end
     end

--- a/lib/shifty/worker.rb
+++ b/lib/shifty/worker.rb
@@ -19,7 +19,7 @@ module Shifty
       @supply       = p[:supply]
       @task         = block || p[:task]
       @context      = p[:context] || OpenStruct.new
-      @policy       = Policy.canonical(p[:policy]) if p[:policy]
+      @policy       = Policy.validate!(p[:policy]) if p[:policy]
       @name         = p[:name]
       self.criteria = p[:criteria]
       self.tags     = p[:tags]
@@ -33,12 +33,18 @@ module Shifty
     # boundary. Public because Policy::Supply routes a task's own
     # supply.shift calls back through it.
     def intake(value)
-      resolved_policy.call(value, worker: self)
+      Policy.resolve(effective_policy).call(value, worker: self)
     end
 
     def shift
       ensure_ready_to_work!
       workflow.resume
+    rescue PolicyError
+      # The raising Fiber is terminated and can never be resumed; discard
+      # it so a caller that rescues the violation can keep shifting.
+      # Closure and context state survive — only the loop restarts.
+      @my_little_machine = nil
+      raise
     end
 
     def ready_to_work?
@@ -104,10 +110,6 @@ module Shifty
 
     def policy_supply
       supply && Policy::Supply.new(supply, self)
-    end
-
-    def resolved_policy
-      @resolved_policy ||= Policy.resolve(effective_policy)
     end
 
     def default_task

--- a/lib/shifty/worker.rb
+++ b/lib/shifty/worker.rb
@@ -9,16 +9,31 @@ module Shifty
   # pipelines, where each worker performs a specific task and passes
   # its output to the next worker in the chain.
   class Worker
-    attr_reader :supply, :tags
+    attr_reader :supply, :tags, :name
+    attr_accessor :pipeline_policy
 
     include Shifty::Taggable
+    include Shifty::PolicyDeclarable
 
     def initialize(p = {}, &block)
       @supply       = p[:supply]
       @task         = block || p[:task]
       @context      = p[:context] || OpenStruct.new
+      @policy       = Policy.canonical(p[:policy]) if p[:policy]
+      @name         = p[:name]
       self.criteria = p[:criteria]
       self.tags     = p[:tags]
+    end
+
+    def effective_policy
+      @policy || pipeline_policy || Shifty.config.default_policy
+    end
+
+    # Applies this worker's effective policy to a value crossing its
+    # boundary. Public because Policy::Supply routes a task's own
+    # supply.shift calls back through it.
+    def intake(value)
+      resolved_policy.call(value, worker: self)
     end
 
     def shift
@@ -59,16 +74,40 @@ module Shifty
       # This is the core of the worker's execution, managed by a Fiber.
       # The Fiber allows the worker to pause its execution (yield) and
       # be resumed later, enabling cooperative multitasking.
+      #
+      # Handoff policy is applied at intake — the moment this worker pulls
+      # a value across its boundary — which is the single seam every value
+      # crosses regardless of how many times an upstream task yielded.
       @my_little_machine ||= Fiber.new {
         loop do
-          value = supply&.shift
+          value = intake(supply&.shift)
           if criteria_passes?
-            Fiber.yield @task.call(value, supply, @context)
+            Fiber.yield perform_task(value)
           else
             Fiber.yield value
           end
         end
       }
+    end
+
+    def perform_task(value)
+      @task.call(value, policy_supply, @context)
+    rescue FrozenError => e
+      raise PolicyViolation.new(
+        worker: self,
+        policy: effective_policy,
+        receiver: e.receiver,
+        value: value,
+        cause: e
+      )
+    end
+
+    def policy_supply
+      supply && Policy::Supply.new(supply, self)
+    end
+
+    def resolved_policy
+      @resolved_policy ||= Policy.resolve(effective_policy)
     end
 
     def default_task
@@ -129,6 +168,4 @@ module Shifty
     # For typical use cases where a Shifty pipeline is built and run, no
     # external threading is usually involved by the user.
   end
-
-  class WorkerError < StandardError; end
 end

--- a/shifty.gemspec
+++ b/shifty.gemspec
@@ -20,10 +20,14 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 3.2"
+
+  spec.add_dependency "ostruct"
+
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "rspec-given", "~> 3.8"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "standard", ">= 1.28.2"
-  spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "simplecov"
 end

--- a/spec/shifty/dsl_spec.rb
+++ b/spec/shifty/dsl_spec.rb
@@ -152,9 +152,17 @@ module Shifty
 
         When { source | worker }
 
-        context ":normal (default)" do
+        context ":normal (default) — a mutating task violates the :frozen default policy" do
           Given(:worker) do
             side_worker(&unsafe_task)
+          end
+
+          Then { expect { worker.shift }.to raise_error(Shifty::PolicyViolation) }
+        end
+
+        context "policy: :shared preserves the classic mutable-reference behavior" do
+          Given(:worker) do
+            side_worker(policy: :shared, &unsafe_task)
           end
 
           Then { worker.shift == [:foo, :boo] }
@@ -163,9 +171,9 @@ module Shifty
           Then { expect(worker.tags).to include(:side_effect) }
         end
 
-        context ":hardened" do
+        context "policy: :isolated — the block's mutations evaporate" do
           Given(:worker) do
-            side_worker mode: :hardened, &unsafe_task
+            side_worker policy: :isolated, &unsafe_task
           end
 
           Then { worker.shift == [:foo] }

--- a/spec/shifty/handoff_policy_spec.rb
+++ b/spec/shifty/handoff_policy_spec.rb
@@ -312,6 +312,107 @@ module Shifty
       end
     end
 
+    describe "eager policy validation at declaration time" do
+      context "Worker.new rejects an unknown policy immediately" do
+        Then do
+          expect { Worker.new(policy: :bogus) { |v| v } }
+            .to raise_error(ArgumentError, /unknown policy :bogus/)
+        end
+      end
+
+      context "Gang.new rejects an unknown policy immediately" do
+        Then do
+          expect { Gang.new([Worker.new { |v| v }], policy: :bogus) }
+            .to raise_error(ArgumentError, /unknown policy :bogus/)
+        end
+      end
+
+      context "the global default rejects an unknown policy immediately" do
+        Then do
+          expect { Shifty.configure { |c| c.default_policy = :bogus } }
+            .to raise_error(ArgumentError, /unknown policy :bogus/)
+        end
+      end
+    end
+
+    describe "recovery after a policy violation" do
+      context "a rescued PolicyViolation does not kill the pipeline" do
+        Given(:source) { source_worker [[:bad], [:good]] }
+        Given(:mutator) do
+          Worker.new { |v| (v == [:bad]) ? v << :x : v }
+        end
+        Given(:pipeline) { source | mutator }
+
+        When(:first_error) do
+          pipeline.shift
+          nil
+        rescue PolicyViolation => e
+          e
+        end
+
+        Then { expect(first_error).to be_a(PolicyViolation) }
+        And { expect(pipeline.shift).to eq([:good]) }
+      end
+    end
+
+    describe "Gang boundary behaviors" do
+      Given(:mutable_source) { Worker.new { [:raw] } }
+
+      context "criteria-bypassed values are still governed at the gang boundary" do
+        Given(:inner) { Worker.new { |v| v } }
+        Given(:gang) { Gang.new([inner], criteria: ->(g) { false }) }
+        Given { gang.supply = mutable_source }
+
+        When(:result) { gang.shift }
+
+        Then { expect(result).to eq([:raw]) }
+        And { expect(result).to be_frozen }
+      end
+
+      context "a worker appended after a policy declaration inherits it" do
+        Given(:early) { Worker.new { |v| v } }
+        Given(:late) { Worker.new { |v| v } }
+        Given(:gang) { Gang[early] }
+        When do
+          gang.with_policy(:isolated)
+          gang.append(late)
+        end
+
+        Then { expect(late.effective_policy).to eq(:isolated) }
+      end
+
+      context "a member's own declaration beats the gang's policy" do
+        Given(:declared) { Worker.new(policy: :shared) { |v| v } }
+        Given!(:gang) { Gang.new([declared], policy: :isolated) }
+
+        Then { expect(declared.effective_policy).to eq(:shared) }
+      end
+
+      context "declaring policy on an empty gang works (populate later)" do
+        Given(:gang) { Gang.new([]) }
+        When(:result) { gang.with_policy(:isolated) }
+        Then { expect(result).to be gang }
+      end
+    end
+
+    describe "with_policy on a self-referential pipe terminates" do
+      Given(:worker) { Worker.new { |v| v } }
+      When(:result) { (worker | worker).with_policy(:isolated) } # standard:disable Lint/BinaryOperatorWithIdenticalOperands
+      Then { expect(result).to be worker }
+      And { expect(worker.effective_policy).to eq(:isolated) }
+    end
+
+    describe "deprecated mode: values other than :hardened warn and are ignored" do
+      Given(:warning) do
+        capture_stderr do
+          @worker = side_worker(mode: :normal) { |v| v }
+        end
+      end
+
+      Then { expect(warning).to match(/mode: option is deprecated and ignored/) }
+      And { expect(@worker.effective_policy).to eq(:frozen) }
+    end
+
     describe "PolicyViolation receiver heuristic" do
       Given(:catch_violation) do
         lambda do |pipeline|
@@ -329,6 +430,19 @@ module Shifty
 
         Then { expect(violation.receiver).to eq([1, 2]) }
         And { expect(violation.receiver).not_to eq(violation.value) }
+        And { expect(violation.message).to match(/reachable from the handed-off value/) }
+      end
+
+      context "mutating an object nested inside a handed-off Struct" do
+        Given(:struct_class) { Struct.new(:items) }
+        Given(:source) do
+          klass = struct_class
+          Worker.new { klass.new([1]) }
+        end
+        Given(:mutator) { Worker.new { |v| v.items << 2 } }
+        When(:violation) { catch_violation.call(source | mutator) }
+
+        Then { expect(violation.receiver).to eq([1]) }
         And { expect(violation.message).to match(/reachable from the handed-off value/) }
       end
 

--- a/spec/shifty/handoff_policy_spec.rb
+++ b/spec/shifty/handoff_policy_spec.rb
@@ -1,0 +1,380 @@
+require "spec_helper"
+
+module Shifty
+  Token = Data.define(:payload)
+
+  RSpec.describe "handoff policy declaration and precedence" do
+    include DSL
+
+    after { Shifty.reset_configuration! }
+
+    describe "worker-level declaration" do
+      context "a worker declaring its own policy uses it" do
+        Given(:worker) { Worker.new(policy: :isolated) { |v| v } }
+        Then { expect(worker.effective_policy).to eq(:isolated) }
+      end
+
+      context "an undeclared worker falls back to the global default" do
+        Given(:worker) { Worker.new { |v| v } }
+        Then { expect(worker.effective_policy).to eq(:frozen) }
+      end
+
+      context "the global default is configurable" do
+        Given { Shifty.configure { |c| c.default_policy = :shared } }
+        Given(:worker) { Worker.new { |v| v } }
+        Then { expect(worker.effective_policy).to eq(:shared) }
+      end
+    end
+
+    describe "pipeline-level declaration via #with_policy" do
+      Given(:source) { Worker.new { |v| v } }
+      Given(:middle) { Worker.new { |v| v } }
+      Given(:declared) { Worker.new(policy: :shared) { |v| v } }
+
+      context "sets the pipeline default on every upstream worker" do
+        Given(:pipeline) { (source | middle).with_policy(:isolated) }
+        Then { expect(pipeline).to be middle }
+        And { expect(middle.effective_policy).to eq(:isolated) }
+        And { expect(source.effective_policy).to eq(:isolated) }
+      end
+
+      context "does not override a worker's own declaration" do
+        When { (source | declared).with_policy(:isolated) }
+        Then { expect(declared.effective_policy).to eq(:shared) }
+        And { expect(source.effective_policy).to eq(:isolated) }
+      end
+
+      context "rejects an unknown policy eagerly" do
+        Then do
+          expect { source.with_policy(:bogus) }
+            .to raise_error(ArgumentError, /unknown policy/)
+        end
+      end
+    end
+
+    describe "enforcement under :frozen (the default)" do
+      context "a task mutating its handed-off value raises PolicyViolation" do
+        Given(:source) { Worker.new { [:foo] } }
+        Given(:mutator) { Worker.new(name: "enricher", tags: [:etl]) { |v| v << :bar } }
+        Given(:pipeline) { source | mutator }
+
+        When(:violation) do
+          pipeline.shift
+          nil
+        rescue PolicyViolation => e
+          e
+        end
+
+        Then { expect(violation).to be_a(PolicyViolation) }
+        And { expect(violation.worker).to be mutator }
+        And { expect(violation.policy).to eq(:frozen) }
+        And { expect(violation.receiver).to eq([:foo]) }
+        And { expect(violation.value).to eq([:foo]) }
+        And { expect(violation.cause).to be_a(FrozenError) }
+        And { expect(violation.message).to match(/enricher/) }
+        And { expect(violation.message).to match(/:frozen/) }
+        And { expect(violation.message).to match(/Array/) }
+        And { expect(violation.message).to match(/the handed-off value itself/) }
+        And { expect(violation.message).to match(/:isolated|:shared/) }
+      end
+    end
+
+    describe "enforcement under :isolated" do
+      context "the task mutates a private copy; upstream is protected, mutation flows on" do
+        Given(:original) { [:foo] }
+        Given(:source) do
+          value = original
+          Worker.new { value }
+        end
+        Given(:appender) { Worker.new(policy: :isolated) { |v| v << :bar } }
+        Given(:pipeline) { source | appender }
+
+        When(:result) { pipeline.shift }
+
+        Then { expect(result).to eq([:foo, :bar]) }
+        And { expect(original).to eq([:foo]) }
+        And { expect(result).not_to be original }
+      end
+    end
+
+    describe "the remaining policy × value-shape cells" do
+      context ":frozen × Data — copy-on-write via #with is the blessed idiom" do
+        Given(:token_class) { Token }
+        Given(:source) { Worker.new { Token.new(payload: "raw") } }
+        Given(:enricher) { Worker.new { |v| v.with(payload: v.payload.upcase) } }
+        When(:result) { (source | enricher).shift }
+
+        Then { expect(result.payload).to eq("RAW") }
+        And { expect(result).to be_frozen }
+      end
+
+      context ":frozen × nil — the end-of-stream sentinel passes through" do
+        Given(:source) { source_worker [:only] }
+        Given(:relay) { relay_worker { |v| v } }
+        Given(:pipeline) { source | relay }
+        When { pipeline.shift }
+        Then { expect(pipeline.shift).to be_nil }
+      end
+
+      context ":isolated × Data with a mutable member — the copy's member is private" do
+        Given(:member) { [1] }
+        Given(:source) do
+          value = member
+          Worker.new { Token.new(payload: value) }
+        end
+        Given(:appender) do
+          Worker.new(policy: :isolated) do |v|
+            v.payload << 2
+            v
+          end
+        end
+        When(:result) { (source | appender).shift }
+
+        Then { expect(result.payload).to eq([1, 2]) }
+        And { expect(member).to eq([1]) }
+      end
+
+      context ":shared × Array — mutation leaks to holders of the same reference" do
+        Given(:original) { [:foo] }
+        Given(:source) do
+          value = original
+          Worker.new { value }
+        end
+        Given(:appender) { Worker.new(policy: :shared) { |v| v << :bar } }
+        When(:result) { (source | appender).shift }
+
+        Then { expect(result).to be original }
+        And { expect(original).to eq([:foo, :bar]) }
+      end
+
+      context ":shared × IO — an unfreezable value passes through untouched" do
+        Given(:io) { File.open(File::NULL, "w") }
+        Given(:source) do
+          value = io
+          Worker.new { value }
+        end
+        Given(:logger) { Worker.new(policy: :shared) { |v| v } }
+        When(:result) { (source | logger).shift }
+
+        Then { expect(result).to be io }
+        And { expect(io).not_to be_frozen }
+      end
+    end
+
+    describe "unshareable values" do
+      context ":frozen × IO raises UnshareableValue without freezing the live handle" do
+        Given(:io) { File.open(File::NULL, "w") }
+        Given(:source) do
+          value = io
+          Worker.new { value }
+        end
+        Given(:consumer) { Worker.new(name: "sink") { |v| v } }
+        Given(:pipeline) { source | consumer }
+
+        When(:error) do
+          pipeline.shift
+          nil
+        rescue UnshareableValue => e
+          e
+        end
+
+        Then { expect(error).to be_a(UnshareableValue) }
+        And { expect(error.policy).to eq(:frozen) }
+        And { expect(error.value).to be io }
+        And { expect(error.message).to match(/:shared/) }
+        And { expect(io).not_to be_frozen }
+        And { expect { io.write("still usable") }.not_to raise_error }
+      end
+
+      context ":frozen × Proc raises UnshareableValue wrapping the Ractor error" do
+        Given(:source) { Worker.new { proc { 1 } } }
+        Given(:consumer) { Worker.new { |v| v } }
+
+        When(:error) do
+          (source | consumer).shift
+          nil
+        rescue UnshareableValue => e
+          e
+        end
+
+        Then { expect(error).to be_a(UnshareableValue) }
+        And { expect(error.cause).to be_a(Ractor::Error) }
+      end
+
+      context ":isolated failure set (the Marshal set)" do
+        Given(:consumer_policy) { :isolated }
+
+        [
+          ["a File", -> { File.open(File::NULL, "w") }],
+          ["a Proc", -> { proc { 1 } }],
+          ["a lazy enumerator", -> { [1, 2].each.lazy }],
+          ["a StringIO", -> { StringIO.new }],
+          ["an object with a singleton method", -> {
+            Object.new.tap { |o|
+              def o.x
+              end
+            }
+          }]
+        ].each do |label, build|
+          context "rejects #{label}" do
+            Given(:source) { Worker.new { build.call } }
+            Given(:consumer) { Worker.new(policy: :isolated) { |v| v } }
+            Then do
+              expect { (source | consumer).shift }
+                .to raise_error(UnshareableValue, /cannot be deep-copied/)
+            end
+          end
+        end
+      end
+    end
+
+    describe "boundary cases" do
+      context "values pulled mid-task via supply.shift are governed (filter_worker)" do
+        Given(:source) { source_worker [[1], [2], [3]] }
+        Given(:filter) { filter_worker { |v| v << :seen } }
+        Given(:pipeline) { source | filter }
+
+        Then { expect { pipeline.shift }.to raise_error(PolicyViolation) }
+      end
+
+      context "every part a splitter yields arrives frozen downstream" do
+        Given(:source) { source_worker ["a-b-c"] }
+        Given(:splitter) { splitter_worker { |v| v.split("-") } }
+        Given(:consumer) { relay_worker { |v| v } }
+        Given(:pipeline) { source | splitter | consumer }
+
+        When(:parts) { 3.times.map { pipeline.shift } }
+
+        Then { expect(parts).to eq(%w[a b c]) }
+        And { expect(parts).to all(be_frozen) }
+      end
+
+      context "trailing_worker under the :frozen default keeps working mid-pipeline" do
+        Given(:source) { source_worker (1..4).to_a }
+        Given(:trailing) { trailing_worker 2 }
+        Given(:consumer) { relay_worker { |v| v } }
+        Given(:pipeline) { source | trailing | consumer }
+
+        When(:results) { 3.times.map { pipeline.shift } }
+
+        Then { expect(results).to eq([[2, 1], [3, 2], [4, 3]]) }
+        And { expect(results.first).to eq([2, 1]) }
+      end
+
+      context "side_worker(policy: :isolated) — mutations evaporate" do
+        Given(:source) { source_worker [[:foo], [:bar]] }
+        Given(:worker) { side_worker(policy: :isolated) { |v| v << :boo } }
+        When { source | worker }
+
+        Then { worker.shift == [:foo] }
+        And { worker.shift == [:bar] }
+        And { worker.shift.nil? }
+      end
+
+      context "a criteria-bypassed value is still policy-governed" do
+        Given(:source) { Worker.new { [:foo] } }
+        Given(:skipper) do
+          Worker.new(criteria: ->(w) { false }) { |v| v }
+        end
+        When(:result) { (source | skipper).shift }
+
+        Then { expect(result).to eq([:foo]) }
+        And { expect(result).to be_frozen }
+      end
+    end
+
+    describe "the :hardened deprecation shim" do
+      Given(:source) { source_worker [[:foo], [:bar]] }
+      Given(:unsafe_task) { proc { |v| v << :boo } }
+
+      context "side_worker mode: :hardened behaves as :isolated and warns" do
+        Given(:warning) do
+          capture_stderr do
+            @worker = side_worker(mode: :hardened, &unsafe_task)
+          end
+        end
+        Given(:pipeline) { source | @worker }
+
+        Then { expect(warning).to match(/:hardened is deprecated/) }
+        And { expect(pipeline.shift).to eq([:foo]) }
+        And { expect(pipeline.shift).to eq([:bar]) }
+      end
+
+      context "Worker policy: :hardened maps to :isolated and warns" do
+        Given(:warning) do
+          capture_stderr do
+            @worker = Worker.new(policy: :hardened) { |v| v }
+          end
+        end
+
+        Then { expect(warning).to match(/:hardened is deprecated/) }
+        And { expect(@worker.effective_policy).to eq(:isolated) }
+      end
+    end
+
+    describe "PolicyViolation receiver heuristic" do
+      Given(:catch_violation) do
+        lambda do |pipeline|
+          pipeline.shift
+          nil
+        rescue PolicyViolation => e
+          e
+        end
+      end
+
+      context "mutating an object nested inside the handed-off value" do
+        Given(:source) { Worker.new { {items: [1, 2]} } }
+        Given(:mutator) { Worker.new { |v| v[:items] << 3 } }
+        When(:violation) { catch_violation.call(source | mutator) }
+
+        Then { expect(violation.receiver).to eq([1, 2]) }
+        And { expect(violation.receiver).not_to eq(violation.value) }
+        And { expect(violation.message).to match(/reachable from the handed-off value/) }
+      end
+
+      context "an unrelated FrozenError from the task's own code is not misattributed" do
+        Given(:own_frozen_thing) { [:mine].freeze }
+        Given(:source) { Worker.new { [:foo] } }
+        Given(:mutator) do
+          thing = own_frozen_thing
+          Worker.new { |v| thing << :other }
+        end
+        When(:violation) { catch_violation.call(source | mutator) }
+
+        Then { expect(violation.receiver).to eq([:mine]) }
+        And { expect(violation.value).to eq([:foo]) }
+        And { expect(violation.message).to match(/may be unrelated to the handed-off value/) }
+      end
+    end
+
+    describe "Gang-level declaration" do
+      Given(:a) { Worker.new { |v| v } }
+      Given(:b) { Worker.new { |v| v } }
+
+      context "policy: kwarg fans out to the roster as pipeline default" do
+        Given!(:gang) { Gang.new([a, b], policy: :isolated) }
+        Then { expect(a.effective_policy).to eq(:isolated) }
+        And { expect(b.effective_policy).to eq(:isolated) }
+      end
+
+      context "#with_policy fans out and is chainable" do
+        Given(:gang) { Gang[a, b] }
+        When(:result) { gang.with_policy(:shared) }
+        Then { expect(result).to be gang }
+        And { expect(a.effective_policy).to eq(:shared) }
+        And { expect(b.effective_policy).to eq(:shared) }
+      end
+
+      context "#with_policy on a chain ending in a worker walks past a gang to upstream workers" do
+        Given(:upstream) { Worker.new { |v| v } }
+        Given(:gang) { Gang[a, b] }
+        Given(:tail) { Worker.new { |v| v } }
+        When { (upstream | gang | tail).with_policy(:isolated) }
+        Then { expect(tail.effective_policy).to eq(:isolated) }
+        And { expect(a.effective_policy).to eq(:isolated) }
+        And { expect(b.effective_policy).to eq(:isolated) }
+        And { expect(upstream.effective_policy).to eq(:isolated) }
+      end
+    end
+  end
+end

--- a/spec/shifty/policy_spec.rb
+++ b/spec/shifty/policy_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+module Shifty
+  RSpec.describe Policy do
+    describe "global configuration" do
+      after { Shifty.reset_configuration! }
+
+      context "out of the box" do
+        Then { expect(Shifty.config.default_policy).to eq(:frozen) }
+      end
+
+      context "configured with a block" do
+        When { Shifty.configure { |c| c.default_policy = :shared } }
+        Then { expect(Shifty.config.default_policy).to eq(:shared) }
+      end
+
+      context "reset restores the default" do
+        Given { Shifty.configure { |c| c.default_policy = :shared } }
+        When { Shifty.reset_configuration! }
+        Then { expect(Shifty.config.default_policy).to eq(:frozen) }
+      end
+    end
+
+    describe ".resolve" do
+      context "returns a policy for each known name" do
+        Then { expect(Policy.resolve(:frozen)).to be Policy::Frozen }
+        And { expect(Policy.resolve(:isolated)).to be Policy::Isolated }
+        And { expect(Policy.resolve(:shared)).to be Policy::Shared }
+      end
+
+      context "rejects an unknown name" do
+        Then do
+          expect { Policy.resolve(:bogus) }
+            .to raise_error(ArgumentError, /unknown policy :bogus/)
+        end
+      end
+
+      context "maps deprecated :hardened to :isolated with a warning" do
+        Given(:warning) do
+          capture_stderr { @resolved = Policy.resolve(:hardened) }
+        end
+        Then { expect(warning).to match(/:hardened is deprecated.*:isolated/m) }
+        And { expect(warning).to match(/removed in 1\.0\.0/) }
+        And { expect(@resolved).to be Policy::Isolated }
+      end
+    end
+  end
+end

--- a/spec/shifty/worker_spec.rb
+++ b/spec/shifty/worker_spec.rb
@@ -80,7 +80,7 @@ module Shifty
 
     describe "#|" do
       Given(:source_worker) { Worker.new { :foo } }
-      Given(:subscribing_worker) { Worker.new { |v| "#{v}_bar".to_sym } }
+      Given(:subscribing_worker) { Worker.new { |v| :"#{v}_bar" } }
 
       When(:pipeline) { source_worker | subscribing_worker }
 
@@ -107,11 +107,11 @@ module Shifty
 
     describe "worker receives a |supply|" do
       Given(:source_worker) { Worker.new { :foo } }
-      Given(:worker) { Worker.new { |value, supply| supply } }
+      Given(:worker) { Worker.new { |value, supply| [value, supply.shift] } }
 
       When(:pipeline) { source_worker | worker }
 
-      Then { pipeline.shift == source_worker }
+      Then { pipeline.shift == [:foo, :foo] }
     end
 
     describe ":tags" do
@@ -163,7 +163,7 @@ module Shifty
 
     describe ":criteria" do
       Given(:source_worker) { Worker.new { :foo } }
-      Given(:worker) { Worker.new(criteria: criteria) { |v| "#{v}_bar".to_sym } }
+      Given(:worker) { Worker.new(criteria: criteria) { |v| :"#{v}_bar" } }
 
       When(:pipeline) { source_worker | worker }
 
@@ -253,7 +253,7 @@ module Shifty
           Given(:context) { OpenStruct.new({foo: "bar"}) }
           Given(:worker) do
             Worker.new(context: context) do |value, supply, context|
-              value && "#{context.foo}_#{value}".to_sym
+              value && :"#{context.foo}_#{value}"
             end
           end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,24 @@ SimpleCov.start
 
 require "rspec/given"
 require "pry"
+require "stringio"
 
 require "shifty"
 
+module StderrCapture
+  def capture_stderr
+    original = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = original
+  end
+end
+
 RSpec.configure do |config|
+  config.include StderrCapture
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 


### PR DESCRIPTION
Part 1 of 4 for the 0.6.0 handoff-immutability release. Implements Phase 1 of
[the implementation plan](docs/planning/feature-implementation-plan.md)
(committed on this branch), which was produced from
[the design doc](docs/planning/handoff-immutability-policies.md) via han planning.

## What this does

Every value crossing a worker boundary is now governed by a **handoff policy**, applied at the consuming worker's intake:

| policy | task receives | mutation in task |
|---|---|---|
| `:frozen` (new default) | deeply frozen shared reference | raises `Shifty::PolicyViolation` at the offending worker |
| `:isolated` | private mutable deep copy (Marshal) | works, stays local |
| `:shared` | the raw reference (old behavior) | works, leaks — the escape hatch |

Declared per worker (`policy:` kwarg — the worker's contract), per pipeline (`.with_policy(...)` on a chain or Gang, `policy:` kwarg on Gang — default for undeclared workers), or globally (`Shifty.configure { |c| c.default_policy = ... }`). Precedence: worker > pipeline > global.

## Design notes (differ from the design doc — empirically driven)

- **`:isolated` uses Marshal, not `make_shareable(copy: true)`**: the latter returns a *frozen* copy, which can't satisfy the mutable-scratch-copy contract.
- **IO is rejected proactively** under `:frozen` (`Shifty::UnshareableValue`): `Ractor.make_shareable` does **not** reject IO — it silently freezes the live handle process-wide (spike verified; it froze `$stdout` mid-experiment).
- Enforcement is at **intake** (one seam + a policy-governed supply proxy for mid-task `supply.shift`), so filter/batch/trailing workers and multi-yield splitter/source workers are covered with no task-body changes.

## Also in this PR

- `trailing_worker` now hands off a snapshot instead of its live closure array (the exact aliasing bug class the policy exists to catch).
- `side_worker mode: :hardened` deprecated → `policy: :isolated` (warning; removal at 1.0.0). Under `:isolated`, a side worker's mutations evaporate — the behavior the docs always wished for.
- Errors consolidated under `Shifty::Error`; `PolicyViolation` carries worker/policy/receiver/value/cause with a receiver-reachability heuristic.
- `required_ruby_version >= 3.2`; `ostruct` declared (not a default gem since Ruby 4); CI matrix 2.6/2.7/3.0 → **3.2/3.3/3.4**; codeclimate-test-reporter dropped (pinned simplecov to 2016).
- Three existing specs that asserted mutation-leaking behavior migrated per plan; they double as migration worked examples.

## Verification

- 130 examples, 0 failures (was 91 at baseline); standardrb clean; `gem build` succeeds.
- Nothing releases from this PR — version stays 0.5.0 until the Phase 4 release PR.

Phases 2–4 (testing harness & mutation detector; benchmarks & `#freeze!`; docs/wiki/release) follow as separate PRs.