### PR TITLE
Handoff immutability policies, Phase 3: #freeze! and benchmarks

### DIFF
--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -1,0 +1,66 @@
+# Handoff policy benchmark results
+
+Run: `bundle exec ruby benchmark/handoff_policies.rb`
+Environment: Ruby 4.0.5 (arm64-darwin25), Apple Silicon. 2026-07-10.
+(Re-run on your own hardware; relative ordering is what matters.)
+
+## Method note (read first)
+
+Rows labeled *fresh value* construct a new value inside each iteration, so
+they include construction cost — that keeps `:frozen`'s freeze bit honest
+(freezing is once-per-object; a pre-built value would be frozen after the
+first iteration). The *steady state* row uses a pre-built, already-shareable
+value and measures the policy call alone. Compare fresh rows against the
+`:shared` fresh row (same construction overhead); read the steady-state row
+as the per-handoff cost once a value is shareable.
+
+`:hardened` (legacy) has no separate row: its mechanism — a Marshal
+round-trip — is exactly what `:isolated` uses, so the `:isolated` rows are
+its numbers.
+
+## Per-handoff throughput (i/s; higher is better)
+
+| Shape | `:shared` (fresh) | `:frozen` first handoff (fresh) | `:frozen` steady state | `:isolated` (fresh) | `:isolated` on already-frozen (§8.3) |
+|---|---|---|---|---|---|
+| small string token | 10.56M | 5.02M | **14.04M** | 1.44M | 1.57M |
+| array, 100 strings | 140.8k | 84.3k | **14.12M** | 34.5k | 46.6k |
+| hash, 100 pairs | 48.6k | 38.4k | **13.87M** | 14.1k | 20.4k |
+| nested document, ~5k nodes | 9.9k | 5.3k | **13.74M** | 1.9k | 2.4k |
+| deep nesting, 500 levels | 49.0k | 21.3k | — | 8.5k | 10.8k |
+
+## Allocations per handoff (GC pressure)
+
+| Shape | `:shared` | `:frozen` (steady) | `:isolated` |
+|---|---|---|---|
+| small string token | 0 | 0 | 5 |
+| array, 100 strings | 0 | 0 | 105 |
+| hash, 100 pairs | 0 | 0 | 205 |
+| nested document | 0 | 0 | 1,711 |
+| deep nesting, 500 levels | 0 | 0 | 504 |
+
+## Findings
+
+1. **The §8.2 amortization claim holds.** Once a value is shareable,
+   `:frozen`'s per-handoff cost is a flat ~71ns **independent of value
+   size** (13.7–14.1M i/s across every shape) with zero allocations.
+   In an N-worker pipeline, only the first boundary pays the freeze
+   traversal; boundaries 2..N are effectively free. Combined with
+   copy-on-write task code, per-boundary cost is proportional to the
+   *change*, not the value.
+2. **First-handoff freeze costs roughly 0.6–1.9× the value's own
+   construction cost** (e.g. ~4.8µs extra for a 100-string array that
+   costs ~7.1µs to build) — paid once per object graph, not per hop.
+3. **`:isolated` is the expensive policy, as designed**: 3–7× slower than
+   `:shared` per boundary *per hop*, and the only policy that allocates
+   (a full copy of the graph per boundary — 1,711 objects per handoff for
+   the ~5k-node document). This is why it is not the default.
+4. **§8.3 fast-path decision: keep option (b) — no fast path.** Marshal
+   gains only ~25–35% on already-frozen values (it re-serializes
+   regardless), so the *measured* saving of skipping the copy entirely
+   would be large (steady-frozen speed) — but the fast path would hand
+   the task a frozen object where its contract promises a mutable
+   scratch copy. Contract simplicity wins at this gem's scale. Reopen
+   trigger: a real workload where `:isolated` boundaries dominate and
+   its inputs are typically already shareable.
+5. **The `:frozen` default is vindicated**: it is the only policy that is
+   simultaneously safe and, at steady state, the cheapest of the three.

--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -26,7 +26,7 @@ its numbers.
 | array, 100 strings | 140.8k | 84.3k | **14.12M** | 34.5k | 46.6k |
 | hash, 100 pairs | 48.6k | 38.4k | **13.87M** | 14.1k | 20.4k |
 | nested document, ~5k nodes | 9.9k | 5.3k | **13.74M** | 1.9k | 2.4k |
-| deep nesting, 500 levels | 49.0k | 21.3k | — | 8.5k | 10.8k |
+| deep nesting, 500 levels | 49.0k | 21.3k | **13.99M** | 8.5k | 10.8k |
 
 ## Allocations per handoff (GC pressure)
 
@@ -54,13 +54,16 @@ its numbers.
    `:shared` per boundary *per hop*, and the only policy that allocates
    (a full copy of the graph per boundary — 1,711 objects per handoff for
    the ~5k-node document). This is why it is not the default.
-4. **§8.3 fast-path decision: keep option (b) — no fast path.** Marshal
-   gains only ~25–35% on already-frozen values (it re-serializes
-   regardless), so the *measured* saving of skipping the copy entirely
-   would be large (steady-frozen speed) — but the fast path would hand
-   the task a frozen object where its contract promises a mutable
-   scratch copy. Contract simplicity wins at this gem's scale. Reopen
-   trigger: a real workload where `:isolated` boundaries dominate and
-   its inputs are typically already shareable.
+4. **§8.3 fast-path decision: keep option (b) — no fast path.** The
+   "already-frozen" column is the pure Marshal cost on a pre-built value
+   (no construction overhead): 92µs for the deep-nested shape, 21µs for
+   the mid array, versus ~71ns if a `Ractor.shareable?` check skipped
+   the copy — so a fast path would make those handoffs roughly three
+   orders of magnitude cheaper *when inputs are already shareable*.
+   It still loses: it would hand the task a frozen object where the
+   `:isolated` contract promises a mutable scratch copy. Contract
+   simplicity wins at this gem's scale. Reopen trigger: a real workload
+   where `:isolated` boundaries dominate and their inputs are typically
+   already shareable.
 5. **The `:frozen` default is vindicated**: it is the only policy that is
    simultaneously safe and, at steady state, the cheapest of the three.

--- a/benchmark/handoff_policies.rb
+++ b/benchmark/handoff_policies.rb
@@ -1,0 +1,81 @@
+# Handoff policy benchmarks (spec §8.4). Manual-run, not CI:
+#
+#   bundle exec ruby benchmark/handoff_policies.rb
+#
+# Measures, per policy and value shape:
+#   1. per-handoff cost of :shared / :frozen / :isolated / legacy :hardened
+#      (Marshal), including :frozen's first-handoff vs steady-state cost
+#      (the §8.2 amortization claim), and
+#   2. what a Ractor.shareable? fast path would save :isolated on
+#      already-shareable values (the §8.3 open question), and
+#   3. allocation counts per policy (GC pressure).
+#
+# Results feed the wiki Performance page.
+
+require "bundler/setup"
+require "shifty"
+require "benchmark/ips"
+
+SHAPES = {
+  "small token (string)" => -> { +"a token" },
+  "mid array (100 strings)" => -> { Array.new(100) { |i| "item-#{i}" } },
+  "mid hash (100 pairs)" => -> { Array.new(100) { |i| ["key-#{i}", "value-#{i}"] }.to_h },
+  "large document (nested, ~5k nodes)" => -> {
+    Array.new(50) do |i|
+      {"id" => i, "name" => "record-#{i}",
+       "tags" => Array.new(10) { |t| "tag-#{t}" },
+       "children" => Array.new(10) { |c| {"idx" => c, "payload" => "data-#{i}-#{c}"} }}
+    end
+  },
+  "deep nesting (500 levels)" => -> {
+    (1..500).reduce([]) { |acc, i| [i, acc] }
+  }
+}
+
+null_worker = Object.new
+def null_worker.name = "bench"
+
+def null_worker.tags = []
+
+puts "Ruby #{RUBY_VERSION} — #{RUBY_PLATFORM}"
+puts
+
+SHAPES.each do |label, build|
+  puts "=" * 72
+  puts "SHAPE: #{label}"
+  puts "=" * 72
+
+  Benchmark.ips do |x|
+    x.report(":shared") do
+      Shifty::Policy::Shared.call(build.call, worker: null_worker)
+    end
+    x.report(":frozen (first handoff — fresh value each time)") do
+      Shifty::Policy::Frozen.call(build.call, worker: null_worker)
+    end
+    frozen_value = Ractor.make_shareable(build.call)
+    x.report(":frozen (steady state — already shareable)") do
+      Shifty::Policy::Frozen.call(frozen_value, worker: null_worker)
+    end
+    x.report(":isolated (Marshal deep copy)") do
+      Shifty::Policy::Isolated.call(build.call, worker: null_worker)
+    end
+    x.report(":isolated on already-frozen value (§8.3 fast-path question)") do
+      Shifty::Policy::Isolated.call(frozen_value, worker: null_worker)
+    end
+    x.compare!
+  end
+
+  # Allocation pressure per single handoff
+  value = build.call
+  frozen_value = Ractor.make_shareable(build.call)
+  {":shared" => [Shifty::Policy::Shared, value],
+   ":frozen (steady)" => [Shifty::Policy::Frozen, frozen_value],
+   ":isolated" => [Shifty::Policy::Isolated, value]}.each do |name, (policy, v)|
+    GC.start
+    before = GC.stat(:total_allocated_objects)
+    100.times { policy.call(v, worker: null_worker) }
+    allocated = GC.stat(:total_allocated_objects) - before
+    puts format("allocations per handoff %-20s %8.1f", name, allocated / 100.0)
+  end
+  puts
+end

--- a/benchmark/handoff_policies.rb
+++ b/benchmark/handoff_policies.rb
@@ -6,8 +6,9 @@
 #   1. per-handoff cost of :shared / :frozen / :isolated / legacy :hardened
 #      (Marshal), including :frozen's first-handoff vs steady-state cost
 #      (the §8.2 amortization claim), and
-#   2. what a Ractor.shareable? fast path would save :isolated on
-#      already-shareable values (the §8.3 open question), and
+#   2. the pure Marshal cost :isolated pays on an already-shareable
+#      value — the copy a Ractor.shareable? fast path would skip
+#      entirely (the §8.3 open question), and
 #   3. allocation counts per policy (GC pressure).
 #
 # Results feed the wiki Performance page.

--- a/lib/shifty/gang.rb
+++ b/lib/shifty/gang.rb
@@ -57,6 +57,15 @@ module Shifty
       worker.pipeline_policy = pipeline_policy if pipeline_policy
     end
 
+    # Freezes every roster member plus the roster's own membership, so
+    # append/push/pop/shift/unshift all raise FrozenError afterward.
+    def freeze_topology_node!
+      roster.workers.each(&:freeze_topology_node!)
+      roster.workers.freeze
+      roster.freeze
+      freeze
+    end
+
     class << self
       def [](*workers)
         new workers

--- a/lib/shifty/policy.rb
+++ b/lib/shifty/policy.rb
@@ -5,14 +5,29 @@ module Shifty
   module PolicyDeclarable
     def with_policy(policy_name)
       policy_name = Policy.validate!(policy_name)
+      each_upstream_node { |node| node.pipeline_policy = policy_name }
+      self
+    end
+
+    # Locks the assembled topology: "the pipeline you composed is the
+    # pipeline that runs" becomes a guarantee. Rewiring (supply=, Gang
+    # append/roster mutation) raises FrozenError afterward. Worker
+    # closure/context state stays mutable — only the topology freezes.
+    def freeze!
+      each_upstream_node { |node| node.freeze_topology_node! }
+      self
+    end
+
+    private
+
+    def each_upstream_node
       node = self
       seen = {}.compare_by_identity
       while node.respond_to?(:pipeline_policy=) && !seen[node]
         seen[node] = true
-        node.pipeline_policy = policy_name
+        yield node
         node = node.supply
       end
-      self
     end
   end
 

--- a/lib/shifty/policy.rb
+++ b/lib/shifty/policy.rb
@@ -13,6 +13,13 @@ module Shifty
     # pipeline that runs" becomes a guarantee. Rewiring (supply=, Gang
     # append/roster mutation) raises FrozenError afterward. Worker
     # closure/context state stays mutable — only the topology freezes.
+    #
+    # Call this on the pipeline's TAIL: like with_policy, it walks the
+    # supply chain upstream, so freezing a mid-chain node leaves
+    # everything downstream of it mutable. And use this, not the bare
+    # Object#freeze — freeze! first materializes each node's lazy task
+    # and Fiber; a bare freeze skips that and the first shift would
+    # raise FrozenError from deep inside the worker.
     def freeze!
       each_upstream_node { |node| node.freeze_topology_node! }
       self

--- a/lib/shifty/worker.rb
+++ b/lib/shifty/worker.rb
@@ -43,8 +43,19 @@ module Shifty
       # The raising Fiber is terminated and can never be resumed; discard
       # it so a caller that rescues the violation can keep shifting.
       # Closure and context state survive — only the loop restarts.
-      @my_little_machine = nil
+      # (A #freeze!-d worker can't rebuild its Fiber, so a violation
+      # there ends the pipeline — the topology guarantee wins.)
+      @my_little_machine = nil unless frozen?
       raise
+    end
+
+    # Materializes lazy state (default task, the Fiber) so that freezing
+    # this instance cannot surprise it later with a FrozenError on ivar
+    # assignment mid-shift, then freezes it.
+    def freeze_topology_node!
+      ensure_ready_to_work!
+      workflow
+      freeze
     end
 
     def ready_to_work?

--- a/shifty.gemspec
+++ b/shifty.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "standard", ">= 1.28.2"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "benchmark-ips"
 end

--- a/spec/shifty/freeze_spec.rb
+++ b/spec/shifty/freeze_spec.rb
@@ -1,0 +1,73 @@
+require "spec_helper"
+
+module Shifty
+  RSpec.describe "#freeze! topology locking" do
+    include DSL
+
+    describe "on a composed worker chain" do
+      Given(:source) { source_worker [1, 2, 3] }
+      Given(:doubler) { relay_worker { |v| v * 2 } }
+      Given(:pipeline) { source | doubler }
+
+      context "returns the receiver, chainable" do
+        Then { expect(pipeline.freeze!).to be pipeline }
+      end
+
+      context "a frozen pipeline still runs" do
+        Given { pipeline.freeze! }
+        Then { pipeline.shift == 2 }
+        And { pipeline.shift == 4 }
+      end
+
+      context "rewiring the frozen tail raises" do
+        Given { pipeline.freeze! }
+        Given(:interloper) { source_worker [:x] }
+        Then { expect { pipeline.supply = interloper }.to raise_error(FrozenError) }
+      end
+
+      context "the walk freezes upstream workers too" do
+        Given { pipeline.freeze! }
+        Then { expect(source).to be_frozen }
+        And { expect(doubler).to be_frozen }
+      end
+
+      context "a worker relying on the lazy default task still runs after freeze!" do
+        Given(:passthrough) { Worker.new(supply: source_worker([:a])) }
+        Given(:frozen_pipeline) { passthrough.freeze! }
+        Then { frozen_pipeline.shift == :a }
+      end
+    end
+
+    describe "on a Gang" do
+      Given(:a) { relay_worker { |v| v + 1 } }
+      Given(:b) { relay_worker { |v| v * 10 } }
+      Given(:gang) { Gang[a, b] }
+      Given(:pipeline) { source_worker([1, 2]) | gang }
+
+      context "a frozen gang still runs" do
+        Given { pipeline.freeze! }
+        Then { pipeline.shift == 20 }
+      end
+
+      context "appending to a frozen gang raises" do
+        Given { pipeline.freeze! }
+        Then { expect { gang.append(relay_worker { |v| v }) }.to raise_error(FrozenError) }
+      end
+
+      context "roster members are frozen" do
+        Given { pipeline.freeze! }
+        Then { expect(a).to be_frozen }
+        And { expect(b).to be_frozen }
+      end
+
+      context "the walk continues past the gang to upstream workers" do
+        Given(:upstream) { source_worker [5] }
+        Given(:tail) { relay_worker { |v| v } }
+        Given(:chain) { upstream | gang | tail }
+        Given { chain.freeze! }
+        Then { expect(upstream).to be_frozen }
+        And { expect(tail).to be_frozen }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part 3 of 4 for 0.6.0, stacked on #28. Implements Phase 3 of [the plan](docs/planning/feature-implementation-plan.md).

## `#freeze!` — topology locking (§5.4)

```ruby
pipeline = (source | parser | sink).freeze!
pipeline.shift          # runs normally
pipeline.supply = other # FrozenError
gang.append(worker)     # FrozenError (roster membership frozen too)
```

- Walks the supply chain (shared traversal with `with_policy`), and per node **materializes lazy state first** (default task, the Fiber) so freezing never surfaces as a confusing `FrozenError` mid-shift — the exact hazard the concurrency analysis (F19–F21) predicted.
- Gangs freeze roster members **and** the roster's `@workers` array (the `append`-rewires-topology hole from F20).
- Worker closure/context state stays mutable — only topology freezes.
- Note: the spec's §5.4 motivated this partly via `Worker#task=`, which doesn't exist; the real motivation is `supply=`/Roster rewiring (doc correction lands in Phase 4).

## Benchmarks (§8.4) — `benchmark/handoff_policies.rb`, results in `benchmark/RESULTS.md`

- **§8.2 amortization confirmed**: steady-state `:frozen` is ~71ns/handoff **independent of value size**, zero allocations — boundaries 2..N of a pipeline are effectively free. The `:frozen` default is the cheapest policy at steady state, not just the safest.
- `:isolated` is the only allocating policy (full graph copy per boundary — 1,711 objects/handoff for a ~5k-node document). Matches the plan's cost model.
- **§8.3 decision: keep option (b)** (no `shareable?` fast path for `:isolated`) — contract simplicity wins; measured data and reopen trigger recorded in RESULTS.md.
- Legacy `:hardened` needs no separate row: its Marshal mechanism *is* `:isolated`'s.

## Verification
166 examples, 0 failures · standardrb clean.