### PR TITLE
Handoff immutability policies, Phase 4: 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+## 0.6.0
+
+The handoff immutability release. Values crossing worker boundaries are now
+governed by a **handoff policy**, and the default changed from raw shared
+references to deeply frozen values. This is a breaking change — see the
+[Migration Guide](https://github.com/joelhelbling/shifty/wiki/Migration-Guide-0.6).
+
+### Breaking changes
+
+- **`:frozen` is the new default handoff policy.** Every value a worker
+  receives is deeply frozen (`Ractor.make_shareable`) at intake. A task that
+  mutates its input now raises `Shifty::PolicyViolation` at the offending
+  worker — immediately and with diagnostics — instead of silently corrupting
+  what downstream workers observe. Restore the old behavior per worker with
+  `policy: :shared`, per pipeline with `.with_policy(:shared)`, or globally
+  with `Shifty.configure { |c| c.default_policy = :shared }`.
+- **Unshareable values can no longer cross a default-policy boundary.**
+  IO handles, procs, lazy enumerators, and (under `:isolated`) anything
+  Marshal rejects raise `Shifty::UnshareableValue` with guidance. Declare
+  `policy: :shared` on workers that pass such values. Note: an IO *nested
+  inside* a container is not detected — declare `:shared` for those workers.
+- **The task's second argument is now a policy-governed supply proxy** that
+  responds to `#shift` only, no longer the raw upstream worker object.
+- **Ruby floor is 3.2** (`required_ruby_version >= 3.2`). Older Rubies stay
+  on shifty 0.5.0.
+- `Shifty::WorkerError` and `Shifty::WorkerInitializationError` are
+  reparented under a new `Shifty::Error` base (still `StandardError`s).
+
+### Deprecations
+
+- **`side_worker mode: :hardened` is deprecated** (removed in 1.0.0); it maps
+  to `policy: :isolated` with a warning. Semantics preserved — both use a
+  Marshal deep copy. Any other `mode:` value now warns and is ignored.
+
+### Added
+
+- **Handoff policies**: `:frozen` (default), `:isolated` (private mutable
+  deep copy; task mutations stay local), `:shared` (raw reference — the
+  escape hatch). Declarable per worker (`policy:` kwarg), per pipeline
+  (`.with_policy(...)` on a chain or Gang, `policy:` kwarg on Gang), and
+  globally. Precedence: worker > pipeline > global.
+- **Rich diagnostics**: `Shifty::PolicyViolation` (worker, policy, receiver,
+  value, cause; a heuristic reports whether the mutated object is the
+  handed-off value, reachable from it, or possibly unrelated) and
+  `Shifty::UnshareableValue`. A rescued `PolicyViolation` does not kill the
+  pipeline — the next `shift` continues with the next value.
+- **Worker `name:` kwarg** for diagnostics.
+- **`Shifty::Testing`** (opt-in `require "shifty/testing"`):
+  `Testing.run(worker, inputs:, policy: nil)` runs a worker through the
+  framework under its production policy; `Testing.mutates_input?` is the
+  mutation detector — the pre-upgrade migration inventory tool.
+- **RSpec sugar** (opt-in `require "shifty/rspec"`): the `mutate_input`
+  matcher and the `"a policy-safe worker"` shared example.
+- **`#freeze!`** locks an assembled pipeline's topology (call it on the
+  tail). Rewiring — `supply=`, Gang `append`, roster mutation — raises
+  `FrozenError`. Worker closure/context state stays mutable.
+- **Benchmark suite** (`benchmark/handoff_policies.rb`, manual-run) with
+  results in `benchmark/RESULTS.md` and on the wiki: steady-state `:frozen`
+  costs ~71ns per handoff regardless of value size, with zero allocations.
+- **In-depth documentation** on the
+  [GitHub wiki](https://github.com/joelhelbling/shifty/wiki): policies,
+  coding idioms under `:frozen`, migration, testing, worker types,
+  performance.
+
+### Fixed
+
+- `trailing_worker` handed off its live internal array; under `:frozen` this
+  is the exact aliasing bug the policies exist to catch. It now hands off a
+  snapshot.
+- `ostruct` is declared as a runtime dependency (no longer a default gem as
+  of Ruby 4).
+- CI now tests Ruby 3.2/3.3/3.4 (was 2.6/2.7/3.0); dropped the abandoned
+  codeclimate-test-reporter (which pinned simplecov to a 2016 release).
+
+## 0.5.0 and earlier
+
+See the [release history](https://github.com/joelhelbling/shifty/releases).

--- a/README.md
+++ b/README.md
@@ -1,19 +1,57 @@
 [![Gem Version](https://badge.fury.io/rb/shifty.svg)](https://badge.fury.io/rb/shifty)
 [![Tests](https://github.com/joelhelbling/shifty/actions/workflows/ruby.yml/badge.svg)](https://github.com/joelhelbling/shifty/actions/workflows/ruby.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/950ded888350c1124348/maintainability)](https://codeclimate.com/github/joelhelbling/shifty/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/950ded888350c1124348/test_coverage)](https://codeclimate.com/github/joelhelbling/shifty/test_coverage)
 
 # The Shifty Framework
 
 _"How many Ruby fibers does it take to screw in a lightbulb?"_
 
+Shifty requires **Ruby 3.2 or newer** as of version 0.6.0. On older Rubies,
+use shifty 0.5.0 (which also retains the classic mutable-handoff behavior).
+
 ## Concurrency Model
 
 Shifty utilizes Ruby Fibers for cooperative multitasking. This means that all tasks (or "workers") run within a single operating system thread and explicitly yield control to one another. This model is intentionally chosen for its simplicity, which makes it easier to reason about and build sequential data processing pipelines.
 
-Single-threading frees you from *preemptive* concurrency hazards (races, mutexes) within a pipeline. It does not, by itself, make the data passing between workers safe — a worker that mutates a value it was handed can still corrupt what later workers see. Governing those handoffs is a separate concern; see the planned [handoff immutability policies](docs/planning/handoff-immutability-policies.md). The Fiber model is also deliberately compatible with a future Ractor-backed worker type, rather than a rejection of parallelism.
+Single-threading frees you from *preemptive* concurrency hazards (races, mutexes) within a pipeline. It does not, by itself, make the data passing between workers safe — a worker that mutates a value it was handed could corrupt what later workers see. As of 0.6.0, those handoffs are governed by [handoff immutability policies](#handoff-policies-new-in-060). The Fiber model is also deliberately compatible with a future Ractor-backed worker type, rather than a rejection of parallelism — and frozen, shareable handoff values are exactly what Ractor boundaries want.
 
 For a more detailed explanation of Shifty's design and typical use cases, please see the [Use Cases Document](docs/use_cases.md).
+
+## Handoff Policies (new in 0.6.0)
+
+Shifty workers are easy to reason about because each one is isolated; the
+values flowing *between* them were, until now, the un-governed part of the
+system. As of 0.6.0, values are **deeply frozen at every handoff by
+default**. Workers that need a private scratch copy can declare
+`policy: :isolated`; workers that genuinely need shared mutable references
+can declare `policy: :shared`. Mutation bugs that used to surface as
+mysterious downstream corruption now either cannot happen or raise
+immediately at the worker responsible — with an error message that tells
+you exactly what to do about it.
+
+```ruby
+# Per worker — part of the worker's contract:
+scratch = Shifty::Worker.new(policy: :isolated) { |v| v << transform(v) }
+
+# Per pipeline — the default for workers that don't declare their own:
+pipeline = (source | parser | sink).with_policy(:shared)
+
+# Globally (the built-in default is :frozen):
+Shifty.configure { |c| c.default_policy = :shared }
+```
+
+| | `:frozen` (default) | `:isolated` | `:shared` |
+|---|---|---|---|
+| The task receives | frozen reference | private mutable deep copy | the raw reference |
+| Mutation in the task | raises `Shifty::PolicyViolation` | works, stays local | works, leaks |
+| Copying per handoff | none | full graph | none |
+
+There's much more in the wiki: [Handoff Policies](https://github.com/joelhelbling/shifty/wiki/Handoff-Policies) in depth,
+[coding idioms under :frozen](https://github.com/joelhelbling/shifty/wiki/Coding-Idioms-Under-Frozen),
+the [0.6 migration guide](https://github.com/joelhelbling/shifty/wiki/Migration-Guide-0.6),
+[testing workers](https://github.com/joelhelbling/shifty/wiki/Testing-Workers), and
+[performance numbers](https://github.com/joelhelbling/shifty/wiki/Performance)
+(spoiler: at steady state, `:frozen` costs about 71 nanoseconds per handoff
+no matter how big the value is).
 
 ## Quick Start
 
@@ -171,10 +209,10 @@ it is, there really isn't a way to prevent the implementation of any
 worker from creating side effects.
 
 _And still wait,_ you'll also be wanting to say, _isn't it possible
-that a side worker could mutate the value as it's passed through?_  And
-again, yes.  It would be very difficult\* in the Ruby language (where
-so many things are passed by reference) to perfectly prevent a side
-worker from mutating the value.  But please don't.
+that a side worker could mutate the value as it's passed through?_
+As of 0.6.0: no, not by accident. A side worker's contract is
+"observe, don't modify," and the default `:frozen` handoff policy
+finally enforces it.
 
 The side effect worker's purpose is to provide _intentionality_ and
 clarity.  When you're creating a side effect, let it be very clear.
@@ -186,54 +224,39 @@ same token, if there is a problem with a side effect, troubleshooting
 it will be much simpler if the side effects are already isolated and
 named.
 
-Another measure for preventing side workers from creating unwanted
-side-effects is to use `:hardened` mode.  That's right, `side_worker`
-has a mode (which defaults to `:normal`).  When set to `:hardened`,
-each value is `Marshal.dump`ed and `Marshal.load`ed before being
-passed to the side worker's callable.  This helps to ensure that
-the original value will be passed through to the next worker in the
-queue in a pristine state (unmodified), and that no future or
-subsequent modification can take place.
-
 Given a source...
 
 ```ruby
 source = source_worker [[:foo], [:bar]]
 ```
 
-Consider this unsafe, unhardened side worker:
+...consider this mutating side worker:
 
 ```ruby
 unsafe = side_worker { |v| v << :boo }
-```
 
-This produces unwanted mutations, because of the `<<`.
-
-```ruby
 pipeline = source | unsafe
 
-pipeline.shift #=> [:foo, :boo] <-- Oh noes!
-pipeline.shift #=> [:bar, :boo] <-- Disaster!
+pipeline.shift #=> raises Shifty::PolicyViolation, naming this worker
+```
+
+Under the default `:frozen` policy that mutation raises immediately,
+at the offending worker. If the side worker's mutations are harmless
+scratch work you'd rather keep, give it a private copy instead:
+
+```ruby
+unsafe = side_worker(policy: :isolated) { |v| v << :boo }
+
+pipeline = source | unsafe
+
+pipeline.shift #=> [:foo] <-- mutations evaporate
+pipeline.shift #=> [:bar] <-- the original flows on, pristine
 pipeline.shift #=> nil
 ```
 
-Let's harden it:
-
-```ruby
-unsafe = side_worker(:hardened) { |v| v << :boo }
-```
-
-The `:hardened` side worker doesn't have access to the original
-value, and therefore its shenanigans are moot with respect to
-the main workflow:
-
-```ruby
-pipeline = source | unsafe
-
-pipeline.shift #=> [:foo] <-- No changes
-pipeline.shift #=> [:bar] <-- Much better
-pipeline.shift #=> nil
-```
+(Old-timers: `side_worker mode: :hardened` still works, mapped to
+`policy: :isolated` with a deprecation warning; it will be removed in
+1.0.0.)
 
 ### Filter Worker
 
@@ -461,7 +484,13 @@ example).
 ## Shifty::Worker
 
 The Shifty::Worker documentation (which was the old README) is now
-[here](docs/shifty/worker.md).
+[here](docs/shifty/worker.md), and the
+[wiki](https://github.com/joelhelbling/shifty/wiki) goes deeper on every
+worker type, handoff policies, testing, migration, and performance.
 
 ## Roadmap
+
+- **1.0.0** — remove the deprecated `:hardened` alias; stabilize the API.
+- **Someday** — a Ractor-backed worker type for true parallelism; the
+  `:frozen` policy's shareable values are deliberately the groundwork.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Shifty.configure { |c| c.default_policy = :shared }
 | Mutation in the task | raises `Shifty::PolicyViolation` | works, stays local | works, leaks |
 | Copying per handoff | none | full graph | none |
 
+### Upgrading from 0.5.0?
+
+Start with the [Migration Guide](https://github.com/joelhelbling/shifty/wiki/Migration-Guide-0.6) —
+it names everything that breaks and gives four migration paths in order of
+preference. `Shifty::Testing.mutates_input?` will inventory which of your
+workers mutate their input *before* you flip the switch.
+
 There's much more in the wiki: [Handoff Policies](https://github.com/joelhelbling/shifty/wiki/Handoff-Policies) in depth,
 [coding idioms under :frozen](https://github.com/joelhelbling/shifty/wiki/Coding-Idioms-Under-Frozen),
 the [0.6 migration guide](https://github.com/joelhelbling/shifty/wiki/Migration-Guide-0.6),
@@ -180,7 +187,7 @@ work.
 source = source_worker (0..3)
 
 evens = []
-even_stasher = side_effect do |value|
+even_stasher = side_worker do |value|
   if value % 2 == 0
     evens << value
   end

--- a/docs/planning/handoff-immutability-policies.md
+++ b/docs/planning/handoff-immutability-policies.md
@@ -1,7 +1,31 @@
-**Status:** Planning
-**Target:** Next major version (breaking change)
+**Status:** Implemented in 0.6.0 (see [feature-implementation-plan.md](feature-implementation-plan.md))
+**Target:** 0.6.0 (pre-1.0 minor carrying the breaking change)
 **Author:** Joel Helbling
 **Last updated:** 2026-07-10
+
+> **Post-implementation corrections.** Empirical spikes during Phase 1
+> falsified three mechanism claims below; the shipped code follows the
+> corrected behavior (design intent unchanged):
+>
+> 1. **§3.2/§10.1:** `:isolated` uses a **Marshal round-trip**, not
+>    `Ractor.make_shareable(copy: true)` — the latter returns a *frozen*
+>    copy and cannot provide the mutable scratch copy the contract
+>    promises. Consequently `:hardened` → `:isolated` preserves the exact
+>    mechanism as well as the semantics.
+> 2. **§3.3/§10.1:** `make_shareable` does **not** reject IO handles or
+>    singleton-methoded objects — it silently freezes a live IO *in
+>    place*, process-wide (and `copy: true` leaks a file descriptor). The
+>    implementation therefore detects top-level IO proactively and raises
+>    `UnshareableValue` before calling `make_shareable`. Only Proc and
+>    `Enumerator::Lazy` (and StringIO) are rejected naturally.
+> 3. **§5.3/§11.4:** `PolicyConflict` was dropped entirely — with worker
+>    declarations authoritative and pipeline policy default-only, no
+>    violable composition rule exists. Reopen alongside a "strict Gang".
+>
+> Also: §5.4's `Worker#task=` never existed; `#freeze!`'s motivation is
+> `supply=`/Roster rewiring. §8.2's amortization claim was validated by
+> benchmarks (`benchmark/RESULTS.md`): steady-state `:frozen` ≈ 71ns per
+> handoff, independent of value size.
 ---
 
 # Handoff Immutability Policies

--- a/docs/shifty/worker.md
+++ b/docs/shifty/worker.md
@@ -31,25 +31,10 @@ relay_worker = Shifty::Worker.new(task: capitalizer, supply: source_worker)
 relay_worker.shift #=> 'Hulk'
 ```
 
-A worker also has an accessor for its @task:
-
-```ruby
-doofusizer = Proc.new { |name| name.gsub(/u/, 'oo') }
-relay_worker.task = doofusizer
-
-relay_worker.shift #=> 'hoolk'
-```
-
-And finally, you can provide a task by directly overriding the
-worker's #task instance method:
-
-```ruby
-def relay_worker.task(name)
-  name.to_sym
-end
-
-relay_worker.shift #=> :hulk
-```
+A worker's task is fixed at construction — there is no `task=`
+accessor. (And as of 0.6.0, `#freeze!` can lock the rest of the
+topology down too, so the pipeline you composed is the pipeline
+that runs.)
 
 Even workers without a task have a task; all workers actually come
 with a default task which simply passes on the received value unchanged:

--- a/docs/shifty/worker.md
+++ b/docs/shifty/worker.md
@@ -1,3 +1,7 @@
+> This page covers the raw `Shifty::Worker` API. The
+> [wiki's Worker-Types page](https://github.com/joelhelbling/shifty/wiki/Worker-Types)
+> covers every DSL worker and their handoff-policy behavior.
+
 # Shifty::Worker
 
 _The workhorse of the Shifty framework._

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -42,15 +42,17 @@ Here are a few conceptual examples of how Shifty could be applied:
 ## A Note on Values Passed Between Workers
 
 The examples above pass data from one worker to the next. Because Shifty runs
-each value through every worker before starting the next value, workers should
+each value through every worker before starting the next value, workers must
 treat a handed-off value as read-only and express changes as new values
 (`arr + [x]`, `hash.merge(...)`, `value.with(...)`) rather than mutating in
-place (`arr <<`, `hash[k] =`, `map!`). This keeps failures local and is the
-direction Shifty is moving: a planned release makes deeply frozen handoffs the
-default, with opt-in policies for workers that genuinely need a private scratch
-copy or a shared mutable reference. See
-[handoff immutability policies](planning/handoff-immutability-policies.md) for
-the full design and migration guidance.
+place (`arr <<`, `hash[k] =`, `map!`). As of 0.6.0 this is enforced: values
+are deeply frozen at every handoff by default, and a task that mutates its
+input raises `Shifty::PolicyViolation` at the offending worker. Workers that
+genuinely need a private scratch copy can declare `policy: :isolated`; workers
+that need a shared mutable reference can declare `policy: :shared`. See the
+wiki's [Handoff Policies](https://github.com/joelhelbling/shifty/wiki/Handoff-Policies)
+and [Coding Idioms Under :frozen](https://github.com/joelhelbling/shifty/wiki/Coding-Idioms-Under-Frozen)
+pages, and the [Migration Guide](https://github.com/joelhelbling/shifty/wiki/Migration-Guide-0.6).
 
 ## Conclusion
 

--- a/docs/wiki/Coding-Idioms-Under-Frozen.md
+++ b/docs/wiki/Coding-Idioms-Under-Frozen.md
@@ -1,0 +1,74 @@
+# Coding Idioms Under `:frozen`
+
+Under the 0.6.0 default policy, every value a worker receives is deeply frozen (see [[Handoff-Policies]]). That sounds restrictive; in practice it asks for one habit: express change as *new values* rather than in-place edits. This page collects the idioms that make `:frozen` pleasant — copy-on-write equivalents, `Data.define` as the value envelope, the "mutable within, immutable between" rule for stateful workers, and the snapshot rule for builders.
+
+## Copy-on-write instead of mutation
+
+Most migrations are a one-character diff. The left column raises `PolicyViolation` under `:frozen`; the right column does the same job non-destructively:
+
+| Mutating (raises under `:frozen`) | Non-destructive equivalent |
+|---|---|
+| `str << "x"`, `str.upcase!` | `str + "x"`, `str.upcase` |
+| `arr << x`, `arr.map!` | `arr + [x]`, `arr.map` |
+| `hash[k] = v`, `hash.merge!` | `hash.merge(k => v)` |
+| `obj.attr = v` | `obj.with(attr: v)` (see below) |
+
+There's a quiet synergy here: copy-on-write creates only delta-sized new structure, and `:frozen`'s freeze traversal only visits objects created since the last handoff. Each half makes the other cheap — see [[Performance]] for the numbers.
+
+## `Data.define` as the value envelope
+
+Ruby 3.2+ `Data` classes are immutable by construction and ship copy-on-update via `#with`:
+
+```ruby
+Token = Data.define(:payload, :meta)
+
+# in a worker task:
+enricher = relay_worker { |v| v.with(payload: enrich(v.payload)) }
+```
+
+`#with` allocates one new outer object and copies member *references*; unchanged members are structurally shared between old and new value. Structural sharing is only safe because the shared substructure is frozen — which under `:frozen` it always is. Freeze and `#with` aren't two features that happen to coexist; they're a matched set.
+
+For plain objects without `#with`, prefer converting them to `Data`; failing that, `clone(freeze: true)` plus constructor patterns work. Shifty deliberately ships no value mixin of its own — stay unopinionated, bring your own envelope.
+
+## Mutable within, immutable between
+
+Closure state remains fully mutable — that is Shifty's design and its selling point for stateful workers, and nothing about it changed in 0.6.0. Workers that *build* values (sources; batch or trailing workers accumulating in closure scope) may mutate freely during construction. The freeze happens at handoff. The framework thereby enforces the functional-core boundary exactly where Shifty always drew it conceptually:
+
+```ruby
+reader = source_worker do
+  buffer = []                 # closure state: mutable, private, fine
+  while (line = io.gets)
+    buffer << line            # construction: mutate freely
+    if buffer.size == 10
+      handoff buffer.join     # handoff: frozen from here on
+      buffer = []
+    end
+  end
+end
+```
+
+Note what got handed off: `buffer.join` — a fresh string, not the buffer itself. Which brings us to:
+
+## The snapshot rule for builders
+
+A builder that hands off an object and *keeps a reference to it* will raise on its next append under `:frozen`. The handoff freezes the live object; the builder's next `<<` hits a frozen array. This is correct — it is exactly the aliasing bug the policy exists to catch — but it means builders that intend to keep building must **hand off a snapshot**: `buffer.dup`, `buffer.join`, `value.with(...)`.
+
+Shifty's own `trailing_worker` is the in-repo example. It accumulates a rolling window in a closure array and keeps mutating it across calls, so it hands off `trail.dup` — a snapshot — rather than the live array, which a downstream `:frozen` intake would otherwise freeze in place:
+
+```ruby
+# from lib/shifty/dsl.rb
+# Hand off a snapshot: the builder keeps mutating `trail` across
+# calls, and a downstream :frozen intake would freeze the live
+# closure array in place.
+trail.dup
+```
+
+If you write custom accumulating workers, follow the same rule.
+
+## Heavy accumulation: persistent data structures
+
+For genuinely large collections under frequent update, `arr + [x]`'s O(n) pointer copy can pinch. The [immutable-ruby](https://github.com/immutable-ruby/immutable-ruby) gem's persistent `Vector` and `Hash` offer O(log n) structurally-shared updates and play nicely with frozen handoffs. This is a documented user-side optimization, **not** a Shifty dependency — reach for it when profiling says so, not before.
+
+## When the idioms don't fit
+
+Some tasks are legitimately mutation-shaped — a third-party proc you don't control, a gnarly legacy transform not worth rewriting. Don't contort them; declare a policy on that worker instead: `policy: :isolated` for a private scratch copy, or `policy: :shared` when downstream really should observe the mutation. See [[Handoff-Policies]] for the trade-offs and [[Migration-Guide-0.6]] for choosing among them.

--- a/docs/wiki/Handoff-Policies.md
+++ b/docs/wiki/Handoff-Policies.md
@@ -1,0 +1,167 @@
+# Handoff Policies
+
+A handoff policy governs how a value crosses a worker boundary. As of 0.6.0 there are three: **`:frozen`** (the default — the value is deeply frozen and passed by reference), **`:isolated`** (the task gets a private mutable deep copy), and **`:shared`** (the raw reference passes through, as in classic Shifty). Policy is applied at *intake* — the moment a worker pulls a value across its boundary — and can be declared per worker, per pipeline/Gang, or globally. This page covers each policy's contract, how declarations compose, the error classes, and the companion `#freeze!` topology lock.
+
+## The three policies
+
+### `:frozen` — the default
+
+The value is deeply frozen in place via `Ractor.make_shareable(value)` and passed **by reference**. Zero copies. Any attempt to mutate the value — or anything reachable from it — raises immediately, at the worker that misbehaved.
+
+- **What the task receives:** a frozen shared reference.
+- **Guarantee:** no worker can mutate a value observed by any other worker.
+- **Cost:** freeze traversal only; no copying, no allocations. Amortized cost is proportional to *newly created* objects, not graph size — at steady state it's a flat ~71ns per handoff regardless of value size (see [[Performance]]).
+- **Developer contract:** tasks must be non-destructive. "Apparent mutation" is expressed as copy-on-write: `value.with(...)`, `arr + [x]`, `hash.merge(...)` (see [[Coding-Idioms-Under-Frozen]]).
+- **Failure modes:** a mutating task raises `Shifty::PolicyViolation`; an unfreezable value raises `Shifty::UnshareableValue` at the handoff. IO values are rejected **proactively** — see below.
+
+### `:isolated` — the scratch-copy mode
+
+The task receives a **deep, mutable copy** of the value, produced by a `Marshal.load(Marshal.dump(value))` round-trip. The task may mutate its copy freely — `<<` and friends work exactly as in classic Shifty code — but nothing leaks back upstream. Whatever the task returns is what flows downstream, mutations included.
+
+Why Marshal and not `Ractor.make_shareable(copy: true)`? Because `make_shareable(copy: true)` returns a *frozen* copy, which cannot satisfy `:isolated`'s contract of a mutable scratch value.
+
+- **What the task receives:** a private mutable deep copy.
+- **Guarantee:** upstream references are protected; task-local mutation is invisible outside the worker.
+- **Cost:** a full deep copy of the value graph per worker, per value, plus the corresponding GC pressure. This is why it is not the default.
+- **Use cases:** mutation-heavy legacy task code not worth rewriting; side workers (this is the old `:hardened` semantics, generalized); untrusted or third-party task procs.
+- **Side workers:** a side worker's return value is discarded, so under `:isolated` its mutations simply evaporate — the behavior the documentation always wished for.
+- **Failure modes:** values Marshal cannot dump raise `Shifty::UnshareableValue`: Procs, lazy enumerators, File/IO handles, StringIO, objects with singleton methods.
+
+### `:shared` — the escape hatch
+
+The raw object reference passes through untouched. This is the pre-0.6.0 default behavior, renamed to say what it actually is. Two legitimate reasons to reach for it:
+
+1. **Intentional in-place mutation** of a value downstream workers are meant to observe.
+2. **Uncopyable / unfreezable values** — IO handles, sockets, procs, lazy enumerators. Sometimes you aren't asking permission to mutate; you're asking for pass-by-reference.
+
+- **Guarantee:** none. The framework provides no protection on this boundary.
+- **Cost:** zero.
+- **Failure mode of incorrect task code:** silent corruption downstream — the very thing 0.6.0 exists to prevent. Reach for `:shared` deliberately, not reflexively.
+
+### Comparison
+
+| | `:frozen` (default) | `:isolated` | `:shared` |
+|---|---|---|---|
+| What the task receives | frozen shared reference | private mutable deep copy | raw shared reference |
+| Upstream protected from mutation | yes (mutation raises) | yes (mutation is local) | no |
+| Mutation in task code | raises `PolicyViolation` | works, stays local | works, leaks |
+| Copying per handoff | none | full graph (Marshal round-trip) | none |
+| Freeze traversal per handoff | delta only (amortized) | none | none |
+| GC pressure | none | high | none |
+| Handles unshareable values (IO, procs, …) | no — `UnshareableValue` | no — `UnshareableValue` (Marshal's failure set) | yes |
+| Failure mode of incorrect task code | loud, local, immediate | silent no-op upstream | silent corruption downstream |
+
+## Declaring policy, and who wins
+
+Policy may be declared at three levels, narrowest to widest. **Precedence: worker beats pipeline beats global.**
+
+```ruby
+# 1. Worker level — part of the worker's contract; always wins
+worker = Shifty::Worker.new(policy: :isolated) { |v| v << transform(v) }
+side_worker(policy: :shared) { |v| logger.info(v) }
+
+# 2. Pipeline level — a default applied to workers that didn't declare their own
+pipeline = (source | parser | enricher | sink).with_policy(:frozen)
+
+# Gangs take a policy at construction or via with_policy; either fans out
+# to the roster, and workers appended later inherit it:
+gang = Shifty::Gang.new([a, b], policy: :isolated)
+Shifty::Gang[a, b].with_policy(:shared)
+
+# 3. Global default — :frozen out of the box
+Shifty.configure { |c| c.default_policy = :frozen }
+```
+
+Details worth knowing:
+
+- `with_policy` walks **upstream** through the supply chain from the node you call it on, so call it on the pipeline's tail (the thing you'd call `shift` on). It returns its receiver, so it chains.
+- A worker's own `policy:` declaration is its **contract** and is never overridden by a pipeline default. This is what makes testing reliable (see [[Testing-Workers]]): any harness that runs the worker through the framework automatically exercises production semantics.
+- Policy names are validated **eagerly**, at declaration time — `Worker.new(policy: :bogus)`, `Gang.new(..., policy: :bogus)`, `with_policy(:bogus)`, and `c.default_policy = :bogus` all raise `ArgumentError` where the typo was written, not at first shift.
+- `:hardened` is accepted as a deprecated alias for `:isolated` (with a warning) until 1.0.0 — see [[Migration-Guide-0.6]].
+- A worker's resolved policy is inspectable as `worker.effective_policy`.
+
+### Where policy is applied
+
+Policy is applied at **intake**: the single seam every value crosses when a worker pulls it from its supply. This includes:
+
+- values pulled mid-task — a task's second argument is a policy-governed supply proxy that responds only to `#shift`, so when a filter, batch, or trailing worker pulls extra values itself, each one crosses the boundary under the same policy;
+- values that bypass a worker's task because its `criteria` said no — the value still crosses the boundary, so it is still governed;
+- each part a splitter yields — every part arrives frozen downstream.
+
+### The terminal-output caveat
+
+Policies govern **worker-to-worker** boundaries only. What the *last* worker returns to your calling code has not crossed another intake, so it is not policy-governed: under `:frozen` it may or may not already be frozen, depending on what the final task did. If your calling code needs a guarantee about the terminal value, establish it yourself (freeze it, copy it, or wrap the pipeline's tail with one more pass-through worker).
+
+## Error reference
+
+Both errors inherit from `Shifty::PolicyError` (< `Shifty::Error` < `StandardError`) and expose `#worker`, `#policy`, and `#value`. Give workers a `name:` and they'll introduce themselves properly in the message.
+
+### `Shifty::PolicyViolation`
+
+Raised when a task mutates a value it received under a policy that forbids mutation. The framework catches the raw `FrozenError` at the task call site and re-raises it wrapped — never masked; the original is available as `#cause`.
+
+Attributes: `worker`, `policy`, `receiver` (the object the task tried to mutate, from `FrozenError#receiver`), `value` (the handed-off value), `cause`.
+
+The message locates the receiver relative to the handed-off value using a bounded reachability walk, producing one of three descriptions:
+
+1. *"…the handed-off value itself"* — the task mutated exactly what it was handed.
+2. *"…reachable from the handed-off value"* — the task mutated something nested inside it (e.g. `v[:items] << 3`).
+3. *"…which may be unrelated to the handed-off value … inspect both to judge"* — the `FrozenError` came from some other frozen object in the task's own code (a frozen string literal, a constant); the policy machinery reports honestly rather than misattributing. (The walk gives up past 50,000 nodes and falls back to this message rather than risk masking the violation.)
+
+Every message ends with the two documented exits: make the task non-destructive (`map` instead of `map!`, `value.with(...)`, `arr + [x]`, `hash.merge(...)`), or declare `policy: :isolated` / `policy: :shared` on that worker.
+
+**Recovery semantics:** a rescued `PolicyViolation` does not kill the pipeline. The raising Fiber is terminated and can never be resumed, so the worker discards it; the next `shift` builds a fresh Fiber and continues with the next value. Closure and context state survive — only the loop restarts. **Exception:** a `#freeze!`-d pipeline cannot rebuild its Fiber, so a violation there ends the pipeline — the topology guarantee wins.
+
+```ruby
+source  = source_worker [[:bad], [:good]]
+mutator = Shifty::Worker.new { |v| (v == [:bad]) ? v << :x : v }
+pipeline = source | mutator
+
+begin
+  pipeline.shift
+rescue Shifty::PolicyViolation => e
+  e.worker   #=> the mutator
+  e.policy   #=> :frozen
+  e.receiver #=> [:bad]
+  e.cause    #=> the original FrozenError
+end
+
+pipeline.shift #=> [:good]  — the pipeline lives on
+```
+
+### `Shifty::UnshareableValue`
+
+Raised at the handoff itself when a value cannot cross the boundary under the effective policy. The failure sets differ per policy:
+
+- **Under `:frozen`:** anything `Ractor.make_shareable` rejects (Procs, lazy enumerators, …), wrapped from the underlying `Ractor::Error` — **plus IO values, rejected proactively**. `make_shareable` does *not* reject an IO; it would silently freeze the live handle in place, a process-wide side effect on shared resources like loggers or `$stdout`. Shifty checks for top-level IO before calling it, and the handle is left untouched and usable.
+- **Under `:isolated`:** anything Marshal cannot dump — Procs, lazy enumerators, File/IO, StringIO, objects with singleton methods.
+
+The message names the value's class and offers the exits: declare `policy: :shared` on this worker (raw pass-by-reference), or restructure the value.
+
+**Caveat:** only a *top-level* IO is detected under `:frozen`. An IO nested inside a container (`{log: $stdout}`) will be silently frozen in place by `make_shareable`. Declare `:shared` on workers handling such values.
+
+### The silent-loosening asymmetry
+
+Error wrapping only catches motion in the *strict* direction. Moving **looser** — `:frozen`/`:isolated` → `:shared` — never raises: a task that was harmlessly mutating its private copy (or that would have raised) now mutates the live shared value, silently. No exception will ever fire. Before loosening any worker's policy, run the mutation detector — `Shifty::Testing.mutates_input?(worker, input)` — to learn whether the task mutates its input at all (see [[Testing-Workers]]).
+
+## `#freeze!` — locking the topology
+
+The same intentionality argument applies to the pipeline itself: `supply=` and Gang appends allow a fully assembled pipeline to be rewired mid-stream. `#freeze!` makes "the pipeline you composed is the pipeline that runs" a guarantee rather than a convention.
+
+```ruby
+pipeline = (source_worker([1, 2, 3]) | relay_worker { |v| v * 2 }).freeze!
+
+pipeline.shift                 #=> 2      — a frozen pipeline still runs
+pipeline.supply = other_source #=> raises FrozenError
+```
+
+What you need to know:
+
+- `#freeze!` locks the node you call it on **and everything upstream** via the supply chain — so call it on the pipeline's **tail**. Freezing a mid-chain node leaves downstream nodes mutable.
+- Worker closure and context state stay mutable — **only the topology freezes**. Stateful workers (batch, trailing, custom accumulators) keep working.
+- Freezing a `Gang` locks its roster membership as well: `append` (and any roster mutation) raises `FrozenError` afterward. The freeze walk continues past the gang to upstream workers.
+- Each worker materializes its lazy state (default task, Fiber) before freezing, so freezing can't surprise it mid-shift. Which is also why you should call `#freeze!` and **not** plain `Object#freeze` — bare `freeze` skips that materialization and will break the worker at its next shift.
+- As noted above, a `#freeze!`-d pipeline cannot recover from a `PolicyViolation` (no Fiber rebuild).
+- `#freeze!` returns its receiver, so it chains: `(a | b | c).with_policy(:frozen).freeze!`.
+
+See also: [[Coding-Idioms-Under-Frozen]] for writing tasks that thrive under the default, and [[Migration-Guide-0.6]] for moving existing pipelines over.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,59 @@
+# The Shifty Framework
+
+Shifty is a Ruby framework for building data processing pipelines out of small, cooperatively multitasking "workers." Each worker is a Fiber-backed unit of work with private state held in closure scope, connected to its neighbors only by the values it hands off. Pipelines are composed with a vertical pipe (`source | transform | sink`), and each value travels through the *entire* pipeline before the next value starts — the escalator, not the elevator.
+
+## What's new in 0.6.0: handoff immutability policies
+
+Shifty workers have always been easy to reason about because each one is isolated; the values flowing *between* them were, until now, the un-governed part of the system. As of 0.6.0, **values are deeply frozen at every handoff by default**. Workers that need a private scratch copy can declare `policy: :isolated`; workers that genuinely need shared mutable references can declare `policy: :shared`. Mutation bugs that used to surface as mysterious downstream corruption now either cannot happen or raise immediately at the worker responsible — with an error message that tells you exactly what to do about it.
+
+0.6.0 also ships:
+
+- **`#freeze!`** — lock a pipeline's topology so the pipeline you composed is the pipeline that runs ([[Handoff-Policies]])
+- **`Shifty::Testing`** and RSpec helpers — unit-test workers under the same policy production will use ([[Testing-Workers]])
+- **Worker `name:`** — so error messages can tell you *which* of nine anonymous workers misbehaved
+- **Benchmarks** demonstrating that the `:frozen` default is essentially free at steady state ([[Performance]])
+- **Deprecation of `side_worker`'s `mode: :hardened`** in favor of `policy: :isolated` ([[Migration-Guide-0.6]])
+
+## Quick start
+
+```ruby
+require "shifty"
+include Shifty::DSL
+
+source  = source_worker (0..3)
+squarer = relay_worker { |n| n ** 2 }
+
+pipeline = source | squarer
+
+pipeline.shift #=> 0
+pipeline.shift #=> 1
+pipeline.shift #=> 4
+pipeline.shift #=> 9
+pipeline.shift #=> nil
+```
+
+Every value the squarer receives arrives deeply frozen. Since the squarer never mutates its input, nothing changes for it — and if some future task tries a sneaky `<<`, it raises a `Shifty::PolicyViolation` right there, naming the worker and the object. Cold cases become caught-in-the-act.
+
+## The pages
+
+| Page | What's in it |
+|---|---|
+| [[Handoff-Policies]] | The three policies (`:frozen`, `:isolated`, `:shared`) in depth: guarantees, costs, failure modes, declaration and precedence, the error reference, and `#freeze!` |
+| [[Coding-Idioms-Under-Frozen]] | Copy-on-write patterns, `Data.define` as the value envelope, and the "mutable within, immutable between" rule |
+| [[Migration-Guide-0.6]] | What breaks, the four migration paths, and the `:hardened` deprecation timeline |
+| [[Testing-Workers]] | `Shifty::Testing.run`, the mutation detector, and the RSpec matcher and shared example |
+| [[Worker-Types]] | The full DSL reference: source, relay, side, filter, batch, splitter, trailing workers, raw `Worker.new`, and `Gang` |
+| [[Performance]] | Benchmark results, why `:frozen` amortizes to ~nothing, and when `:isolated`'s cost matters |
+
+## Ruby version support
+
+| Shifty version | Ruby requirement | Notes |
+|---|---|---|
+| **0.6.0** | Ruby >= 3.2 | Handoff policies, `Data`-based idioms, `#freeze!`, testing harness |
+| 0.5.0 | older Rubies | Last release with the previous defaults (`:shared`-style handoffs, `side_worker mode: :hardened`); remains available for older Rubies and legacy patterns |
+
+The 3.2 floor aligns the gem with `Data.define` (the recommended value envelope — see [[Coding-Idioms-Under-Frozen]]) and mature `Ractor.make_shareable` behavior, which powers the `:frozen` policy.
+
+## Concurrency model, in one paragraph
+
+Shifty uses Ruby Fibers for cooperative multitasking: all workers run in a single OS thread and explicitly yield to one another, which frees you from *preemptive* hazards (races, mutexes) within a pipeline. Single-threading never made the *data* between workers safe, though — that is exactly what handoff policies now govern. The frozen, Ractor-shareable values that `:frozen` produces are also deliberately compatible with a possible future Ractor-backed worker type.

--- a/docs/wiki/Migration-Guide-0.6.md
+++ b/docs/wiki/Migration-Guide-0.6.md
@@ -1,0 +1,93 @@
+# Migrating to 0.6.0
+
+Shifty 0.6.0 changes the default handoff behavior: values now arrive at each worker **deeply frozen** instead of as raw shared references (see [[Handoff-Policies]]). Most pipelines — anything already written in a non-destructive style — upgrade with no changes at all. Pipelines whose tasks mutate their inputs will raise loudly and immediately, with an error message that names the worker, the object, and the fix. This page covers what breaks, the four migration paths in order of preference, and the deprecation timeline.
+
+## What breaks
+
+1. **The default flips from `:shared` to `:frozen`.** Any task that mutates its input (`<<`, `map!`, `merge!`, attribute assignment) raises `Shifty::PolicyViolation` on first contact — at the offending worker, not downstream. The message tells you which worker, which object, and the two exits.
+
+2. **Unshareable values can't cross a default-policy boundary.** IO handles, sockets, procs, lazy enumerators, and (under `:isolated`) objects with singleton methods raise `Shifty::UnshareableValue` at the handoff. Workers passing such values along must declare `policy: :shared`. Note that IO is rejected proactively under `:frozen` — but only *top-level* IO; an IO nested inside a container is silently frozen in place by `Ractor.make_shareable`, so declare `:shared` on workers handling those too.
+
+3. **`side_worker`'s `mode:` option is deprecated.** `mode: :hardened` maps to `policy: :isolated` with a deprecation warning; any other `mode:` value warns and is ignored. Note that `side_worker` now takes an options hash, so the old *positional* form `side_worker(:hardened) { ... }` must become `side_worker(mode: :hardened)` (transitional, warns) or better, `side_worker(policy: :isolated)`. The `mode:` option (and the `:hardened` policy alias) will be **removed in 1.0.0**.
+
+4. **The task's second argument is now a policy-governed supply proxy.** Tasks that accept `(value, supply)` — filters, batchers, anything pulling extra values mid-task — now receive a proxy responding only to `#shift`, not the raw upstream worker. Each pulled value crosses the boundary under the worker's policy, exactly like the primary intake. If your task called anything other than `#shift` on its supply argument, that code needs rework.
+
+5. **Ruby floor is 3.2** (`required_ruby_version` in the gemspec). Shifty 0.5.0 remains available for older Rubies and the old behavior.
+
+## Migration paths, in order of preference
+
+### 1. Rewrite tasks non-destructively
+
+Usually a small diff — `map!` → `map`, `<<` → `+`, `merge!` → `merge` — and the `PolicyViolation` message names the object and the worker for you. This is the best destination: zero policy declarations, zero copies, full protection. See [[Coding-Idioms-Under-Frozen]] for the full pattern table.
+
+```ruby
+# before                                  # after
+relay_worker { |v| v << compute(v) }      relay_worker { |v| v + [compute(v)] }
+```
+
+### 2. Declare `:isolated` on mutation-heavy workers
+
+When a task isn't worth rewriting, give it a private scratch copy. Correctness is preserved; the deep-copy cost is localized to exactly those workers.
+
+```ruby
+legacy = Shifty::Worker.new(policy: :isolated) { |v| gnarly_in_place_transform(v) }
+```
+
+### 3. Declare `:shared` where pass-by-reference is genuinely required
+
+Uncopyable values, or intentional shared mutation observed downstream. This restores the pre-0.6.0 semantics for that worker only — along with its lack of protection, so use deliberately.
+
+```ruby
+log_forwarder = side_worker(policy: :shared) { |io| io.flush }
+```
+
+### 4. Blanket opt-out (large legacy codebases)
+
+```ruby
+Shifty.configure { |c| c.default_policy = :shared }
+```
+
+This reproduces 0.5.0 behavior globally, letting a team migrate worker-by-worker at its own pace. Treat it as scaffolding, not a destination — while it's in place you have none of 0.6.0's protection anywhere a worker hasn't declared its own policy.
+
+## Inventory first: the mutation detector
+
+Before upgrading (or before loosening any policy), let the framework tell you which workers actually mutate their inputs:
+
+```ruby
+require "shifty/testing"
+
+Shifty::Testing.mutates_input?(worker, representative_input)
+#=> true  — needs path 1, 2, or 3
+#=> false — this worker upgrades clean
+```
+
+Run it across your workers with representative inputs and you have your migration worklist. This matters doubly because loosening is *silent*: moving a worker to `:shared` never raises, even if its task mutates — the detector is the only thing that will tell you. See [[Testing-Workers]].
+
+## `:hardened` → `:isolated`: what's preserved, what changed
+
+The old `side_worker(:hardened)` handed the block a `Marshal.load(Marshal.dump(value))` deep copy. `:isolated` uses **the same Marshal round-trip**, so both semantics and failure behavior are preserved: a value that raised under `:hardened` (a proc, an IO, a singleton-methoded object — anything Marshal rejects) still raises under `:isolated`, now as a `Shifty::UnshareableValue` with a diagnostic message instead of a bare `TypeError`. No value that used to fail will start silently succeeding, and vice versa.
+
+(An earlier design draft had `:isolated` using `Ractor.make_shareable(copy: true)`, which would have shifted the failure set slightly — that mechanism returns a frozen copy and was rejected precisely because `:isolated` promises a *mutable* scratch copy.)
+
+## Deprecation timeline
+
+| Version | Status |
+|---|---|
+| 0.6.0 | `mode: :hardened` and `policy: :hardened` work, emit deprecation warnings, map to `:isolated` |
+| 1.0.0 | `mode:` option and `:hardened` alias removed |
+
+## A worked upgrade
+
+```ruby
+# 0.5.0 code
+source = source_worker [[:foo], [:bar]]
+stasher = side_worker(:hardened) { |v| v << :boo }   # old positional mode
+
+# 0.6.0 code — same behavior, no warning
+stasher = side_worker(policy: :isolated) { |v| v << :boo }
+
+pipeline = source | stasher
+pipeline.shift #=> [:foo]   — mutations evaporate, value passes through pristine
+```
+
+And remember: policy names are validated eagerly, so typos in `policy:` declarations fail at the declaration site, not three workers downstream at 2 a.m.

--- a/docs/wiki/Migration-Guide-0.6.md
+++ b/docs/wiki/Migration-Guide-0.6.md
@@ -82,6 +82,9 @@ The old `side_worker(:hardened)` handed the block a `Marshal.load(Marshal.dump(v
 # 0.5.0 code
 source = source_worker [[:foo], [:bar]]
 stasher = side_worker(:hardened) { |v| v << :boo }   # old positional mode
+# NOTE: on 0.6.0 this positional form raises TypeError (side_worker now
+# takes an options hash) — it does NOT get the friendly deprecation
+# warning. Only the keyword forms (mode:/policy:) warn.
 
 # 0.6.0 code — same behavior, no warning
 stasher = side_worker(policy: :isolated) { |v| v << :boo }

--- a/docs/wiki/Performance.md
+++ b/docs/wiki/Performance.md
@@ -1,0 +1,59 @@
+# Performance
+
+Shifty 0.6.0's `:frozen` default was chosen on a claim: deep-freezing at every handoff amortizes to approximately nothing, while deep-copying (`:isolated`) does not. The benchmark suite in `benchmark/` verifies it. Headline: once a value is shareable, `:frozen` costs a flat **~71ns per handoff with zero allocations, independent of value size** — at steady state it is the *cheapest* of the three policies, not just the safest. Numbers below are from Apple Silicon; re-run on your own hardware — the relative ordering is what matters.
+
+## Method note (read first)
+
+Rows labeled *fresh value* construct a new value inside each iteration, so they include construction cost — that keeps `:frozen`'s freeze bit honest (freezing is once-per-object; a pre-built value would be frozen after the first iteration). The *steady state* column uses a pre-built, already-shareable value and measures the policy call alone. Compare fresh columns against the `:shared` fresh column (same construction overhead); read the steady-state column as the per-handoff cost once a value is shareable.
+
+`:hardened` (legacy) has no separate row: its mechanism — a Marshal round-trip — is exactly what `:isolated` uses, so the `:isolated` columns are its numbers.
+
+## Per-handoff throughput (i/s; higher is better)
+
+| Shape | `:shared` (fresh) | `:frozen` first handoff (fresh) | `:frozen` steady state | `:isolated` (fresh) | `:isolated` on already-frozen |
+|---|---|---|---|---|---|
+| small string token | 10.56M | 5.02M | **14.04M** | 1.44M | 1.57M |
+| array, 100 strings | 140.8k | 84.3k | **14.12M** | 34.5k | 46.6k |
+| hash, 100 pairs | 48.6k | 38.4k | **13.87M** | 14.1k | 20.4k |
+| nested document, ~5k nodes | 9.9k | 5.3k | **13.74M** | 1.9k | 2.4k |
+| deep nesting, 500 levels | 49.0k | 21.3k | — | 8.5k | 10.8k |
+
+## Allocations per handoff (GC pressure)
+
+| Shape | `:shared` | `:frozen` (steady) | `:isolated` |
+|---|---|---|---|
+| small string token | 0 | 0 | 5 |
+| array, 100 strings | 0 | 0 | 105 |
+| hash, 100 pairs | 0 | 0 | 205 |
+| nested document | 0 | 0 | 1,711 |
+| deep nesting, 500 levels | 0 | 0 | 504 |
+
+## Findings
+
+1. **The amortization claim holds.** Once a value is shareable, `:frozen`'s per-handoff cost is a flat ~71ns **independent of value size** (13.7–14.1M i/s across every shape) with zero allocations. In an N-worker pipeline, only the first boundary pays the freeze traversal; boundaries 2..N are effectively free. Combined with copy-on-write task code, per-boundary cost is proportional to the *change*, not the value.
+2. **First-handoff freeze costs roughly 0.6–1.9× the value's own construction cost** (e.g. ~4.8µs extra for a 100-string array that costs ~7.1µs to build) — paid once per object graph, not per hop.
+3. **`:isolated` is the expensive policy, as designed**: 3–7× slower than `:shared` per boundary *per hop*, and the only policy that allocates — a full copy of the graph per boundary, 1,711 objects per handoff for the ~5k-node document. This is why it is not the default.
+4. **No `shareable?` fast path for `:isolated`.** An already-frozen input can't be mutated by anyone, so `:isolated` could skip the copy — but the fast path would hand the task a frozen object where its contract promises a mutable scratch copy. Marshal only gains ~25–35% on already-frozen values (it re-serializes regardless), so contract simplicity wins at this gem's scale. Reopen trigger: a real workload where `:isolated` boundaries dominate and its inputs are typically already shareable.
+5. **The `:frozen` default is vindicated**: it is the only policy that is simultaneously safe and, at steady state, the cheapest of the three. Freeze once, shift forever.
+
+## Why `:frozen` amortizes
+
+MRI marks objects shareable once `Ractor.make_shareable` has blessed them, and the traversal short-circuits on already-shareable subgraphs. So in a `:frozen` pipeline, the *first* handoff pays a full traversal of the value; every subsequent handoff — through however many downstream workers — traverses only objects created since the previous one. Write your tasks copy-on-write ([[Coding-Idioms-Under-Frozen]]) and each worker creates only delta-sized new structure, so each boundary freezes only that delta. The value's bulk rides through the whole pipeline on that flat ~71ns already-shareable check, allocating nothing.
+
+## When `:isolated`'s cost matters
+
+`:isolated` copies the **entire value graph at every boundary it governs** — per worker, per value. Rules of thumb:
+
+- **Token-sized values, a few `:isolated` workers:** noise. Don't think about it.
+- **Large values (parsed documents, big collections) through `:isolated` boundaries:** a serious tax, in both CPU (3–7× vs `:shared`) and GC pressure (thousands of allocations per handoff). Often the GC cost outstrips the copy CPU itself.
+- **Many `:isolated` workers in one pipeline:** costs multiply — nine `:isolated` workers means nine full copies and nine graphs of garbage per value.
+
+The remedy is targeted: keep `:isolated` on exactly the workers that need a scratch copy, and migrate hot ones to non-destructive tasks under `:frozen` (see [[Migration-Guide-0.6]]). `Shifty::Testing.mutates_input?` tells you which workers actually still need it ([[Testing-Workers]]).
+
+## Re-running the benchmarks
+
+```
+bundle exec ruby benchmark/handoff_policies.rb
+```
+
+Results are written up in [`benchmark/RESULTS.md`](https://github.com/joelhelbling/shifty/blob/main/benchmark/RESULTS.md). Absolute numbers vary by hardware and Ruby version; the shape of the results — flat steady-state `:frozen`, graph-proportional `:isolated` — should not.

--- a/docs/wiki/Performance.md
+++ b/docs/wiki/Performance.md
@@ -16,7 +16,7 @@ Rows labeled *fresh value* construct a new value inside each iteration, so they 
 | array, 100 strings | 140.8k | 84.3k | **14.12M** | 34.5k | 46.6k |
 | hash, 100 pairs | 48.6k | 38.4k | **13.87M** | 14.1k | 20.4k |
 | nested document, ~5k nodes | 9.9k | 5.3k | **13.74M** | 1.9k | 2.4k |
-| deep nesting, 500 levels | 49.0k | 21.3k | — | 8.5k | 10.8k |
+| deep nesting, 500 levels | 49.0k | 21.3k | **13.99M** | 8.5k | 10.8k |
 
 ## Allocations per handoff (GC pressure)
 

--- a/docs/wiki/Testing-Workers.md
+++ b/docs/wiki/Testing-Workers.md
@@ -1,0 +1,127 @@
+# Testing Workers
+
+Shifty 0.6.0 ships an opt-in test harness (`require "shifty/testing"`) and RSpec sugar (`require "shifty/rspec"`) so your unit tests exercise workers under the **same handoff policy the production pipeline will** (see [[Handoff-Policies]]). Neither is loaded by `require "shifty"` — they're deliberately opt-in. This page covers the parity problem they solve, `Shifty::Testing.run`, the mutation detector, the RSpec matcher and shared example, and the "test at the ceiling" guidance.
+
+## The parity problem
+
+A pipeline runs `:frozen`; a unit test exercises the worker's raw proc with an ordinary mutable object:
+
+```ruby
+worker.task.call(input)  # bypasses the framework — and the policy
+```
+
+The test passes; the pipeline raises. The gap closes from two directions:
+
+1. **Worker-level policy declarations win** over pipeline defaults, so the policy travels *with* the worker. Any test that runs the worker through the framework automatically exercises production semantics.
+2. **The framework path is the convenient path** — that's `Shifty::Testing.run`.
+
+With `:frozen` as the global default, the common case requires no test configuration at all.
+
+## `Shifty::Testing.run`
+
+```ruby
+require "shifty/testing"
+
+Shifty::Testing.run(worker, inputs:, policy: nil, max_shifts: 10_000)
+```
+
+Feeds the inputs to the worker via a synthetic source and collects its outputs until the end-of-stream sentinel (`nil`). The worker's declared/effective policy governs each handoff, exactly as in production; the harness restores the worker's policy, supply, and Fiber afterward, so it never leaves a mark on the worker under test.
+
+```ruby
+worker = relay_worker { |v| v.upcase }
+Shifty::Testing.run(worker, inputs: ["a", "b", "c"])  #=> ["A", "B", "C"]
+
+# Parity with production — a mutating task raises under the default policy:
+mutator = Shifty::Worker.new { |v| v && v << :x }
+Shifty::Testing.run(mutator, inputs: [[:a]])          # raises PolicyViolation
+
+# A worker that declared :isolated runs under :isolated:
+scratch = Shifty::Worker.new(policy: :isolated) { |v| v && v << :x }
+Shifty::Testing.run(scratch, inputs: [[:a]])          #=> [[:a, :x]]
+
+# Explicit policy: override beats the worker's declaration (policy-matrix testing);
+# the worker's real declaration is untouched afterward:
+loose = Shifty::Worker.new(policy: :shared) { |v| v && v << :x }
+Shifty::Testing.run(loose, inputs: [[:a]], policy: :frozen)  # raises PolicyViolation
+loose.effective_policy                                       #=> :shared
+
+# Non-1:1 output streams collect naturally:
+evens = filter_worker { |v| v.even? }
+Shifty::Testing.run(evens, inputs: [1, 2, 3, 4])      #=> [2, 4]
+```
+
+### Sentinel semantics
+
+`nil` is Shifty's end-of-stream sentinel; collection stops at the first `nil` output. **`false` is a legitimate payload**, not end-of-stream — it flows through and gets collected:
+
+```ruby
+flipper = relay_worker { |v| !v }
+Shifty::Testing.run(flipper, inputs: [true, false, true])
+#=> [false, false, false]
+# (relay_worker's `value &&` guard passes the false input through untouched.)
+```
+
+If a worker's task converts `nil` into something non-nil, the run would never terminate — so after `max_shifts` (default 10,000) the harness raises a diagnostic `Shifty::Error` telling you to let `nil` pass through (e.g. `value && ...`) or raise `max_shifts:`.
+
+## The mutation detector: `mutates_input?`
+
+```ruby
+Shifty::Testing.mutates_input?(worker, input)  #=> true / false
+```
+
+Hands the task a private mutable deep copy of `input`, runs it through the framework under `:shared`, and compares the copy before and after (via `Marshal.dump`). It surfaces mutation **even when the worker's current policy permits or hides it**:
+
+```ruby
+sneaky = side_worker(policy: :isolated) { |v| v << :boo }
+Shifty::Testing.mutates_input?(sneaky, [:a])  #=> true — the :isolated copy hid it in production
+
+clean = relay_worker { |v| v + [:x] }
+Shifty::Testing.mutates_input?(clean, [:a])   #=> false
+```
+
+This is exactly the information you need **before** loosening a policy — moving to `:shared` never raises, so the detector is your only warning (the silent-loosening asymmetry; see [[Handoff-Policies]]). It's also the pre-upgrade inventory tool for [[Migration-Guide-0.6]]. The input must be Marshal-dumpable; anything else raises a descriptive `Shifty::Error`.
+
+## RSpec sugar
+
+```ruby
+# spec_helper.rb
+require "shifty/rspec"   # pulls in shifty/testing; assumes RSpec is loaded
+```
+
+### The `mutate_input` matcher
+
+Takes the input as an argument and delegates to the mutation detector:
+
+```ruby
+expect(worker).not_to mutate_input([:a])
+```
+
+The negated failure message spells out the consequences: a mutating task is only correct under `:isolated` (mutation stays local) or `:shared` (mutation is intentional); it will raise under `:frozen`.
+
+### The `"a policy-safe worker"` shared example
+
+Expects `worker` and `safe_input` to be defined with `let`:
+
+```ruby
+RSpec.describe "my enricher" do
+  let(:worker)     { relay_worker { |v| v.merge(enriched: true) } }
+  let(:safe_input) { {id: 1} }
+
+  it_behaves_like "a policy-safe worker"
+end
+```
+
+It runs two checks: the worker processes a **deeply frozen** input through the framework without raising (`Testing.run(..., policy: :frozen)`), and it does not mutate its input.
+
+## Test at the ceiling
+
+Policy safety is (almost) a one-way ratchet: a task correct on deeply frozen input is correct under every policy; the reverse does not hold. So the guidance is to **test under `:frozen`** — the ceiling — unless the worker explicitly declares mutation as part of its design. Consequences:
+
+- Loosening a pipeline's policy can never break a ceiling-tested worker.
+- Tightening is the only breaking direction, and tightening fails loudly with `PolicyViolation` diagnostics.
+
+**The "almost":** `:isolated` hands the task a *copy*, so a worker depending on object **identity** (rare, but conceivable with identity-keyed caches) behaves differently there. This is the one spot where strict-passing does not imply lax-passing. If your worker cares about `equal?`, test it under `:isolated` explicitly:
+
+```ruby
+Shifty::Testing.run(worker, inputs: [thing], policy: :isolated)
+```

--- a/docs/wiki/Worker-Types.md
+++ b/docs/wiki/Worker-Types.md
@@ -1,0 +1,171 @@
+# Worker Types
+
+Shifty's DSL (`include Shifty::DSL`) provides shorthand constructors for the common worker shapes; underneath them all is `Shifty::Worker`, and above them sits `Shifty::Gang` for treating a chain as one unit. This page is the per-type reference for 0.6.0, including how each type behaves under the default `:frozen` handoff policy (see [[Handoff-Policies]]). All DSL constructors except `source_worker` and `trailing_worker` accept an options hash that passes through to `Worker.new` — so `policy:`, `name:`, `tags:` work everywhere.
+
+## `source_worker`
+
+At the headwater of every pipeline: a worker that generates its own work items. Its block takes no arguments; `nil` signals end-of-stream (and once a source returns `nil`, it returns `nil` henceforth).
+
+```ruby
+worker = source_worker { "Number 9" }   # generates forever
+
+counter = 0
+finite = source_worker do               # generates until it returns nil
+  if counter < 3
+    counter += 1
+    counter + 1000
+  end
+end
+
+w1 = source_worker [0, 1, 2]            # or hand it a series
+w2 = source_worker (0..2)               # ranges work too
+```
+
+A series-based source yields each element and then `nil` forever. Strings are split into characters; a bare scalar becomes a one-element series. You can also combine a series with a block, which acts as a transform: `source_worker([1,2]) { |v| v * 10 }`.
+
+Sources are where "mutable within, immutable between" starts: build values freely in closure scope, and hand off snapshots (see [[Coding-Idioms-Under-Frozen]]).
+
+## `relay_worker`
+
+The most "normal" worker: accepts a value, returns a transformation of it. `nil` passes through untouched (the end-of-stream sentinel survives).
+
+```ruby
+squarer = relay_worker { |number| number ** 2 }
+pipeline = source_worker(0..3) | squarer
+pipeline.shift #=> 0, 1, 4, 9, nil
+```
+
+Under `:frozen`, relay tasks must be non-destructive — `v.merge(...)`, `v + [...]`, `v.with(...)`. A `v <<` raises `PolicyViolation` at this worker, by name if you gave it one.
+
+## `side_worker`
+
+Passes through the value it received while performing a side effect — logging, metrics, stashing. Its purpose is *intentionality*: side effects live in named, removable workers, so pulling one out of the pipeline never changes the pipeline's output.
+
+```ruby
+evens = []
+even_stasher = side_worker { |value| evens << value if value.even? }
+```
+
+Policy behavior is where 0.6.0 makes the side worker's contract real:
+
+- **Under `:frozen` (default):** a block that mutates the passed value raises `PolicyViolation`. Observation is enforced.
+- **Under `:isolated`:** the block observes a private scratch copy; since a side worker's return value is discarded, its mutations simply **evaporate** and the untouched value flows on:
+
+```ruby
+source = source_worker [[:foo], [:bar]]
+unsafe = side_worker(policy: :isolated) { |v| v << :boo }
+pipeline = source | unsafe
+pipeline.shift #=> [:foo]  — shenanigans contained
+pipeline.shift #=> [:bar]
+```
+
+- **`mode:` is deprecated:** `mode: :hardened` maps to `policy: :isolated` with a warning; any other `mode:` value warns and is ignored. Removed in 1.0.0 — see [[Migration-Guide-0.6]].
+
+## `filter_worker`
+
+Passes through only values for which the block is truthy; falsy values are discarded (the worker pulls from its supply until something passes).
+
+```ruby
+evens_only = filter_worker { |value| value % 2 == 0 }
+pipeline = source_worker(0..5) | evens_only
+pipeline.shift #=> 0, 2, 4, nil
+```
+
+Every value the filter pulls mid-task crosses the boundary under the worker's policy — including the ones it discards.
+
+## `batch_worker`
+
+Gathers values into batches. Either a fixed size:
+
+```ruby
+batch = batch_worker gathering: 3
+pipeline = source_worker(0..7) | batch
+pipeline.shift #=> [0, 1, 2], then [3, 4, 5], then [6, 7], then nil
+```
+
+(the final batch may be short), or a condition — batch until the block is truthy:
+
+```ruby
+line_reader = batch_worker { |value| value.end_with?("\n") }
+```
+
+## `splitter_worker`
+
+Accepts one value, produces an array from it, and hands off each element successively before asking its supply for more.
+
+```ruby
+splitter = splitter_worker { |value| value.split(" ") }
+pipeline = source_worker(["A bold", "move westward"]) | splitter
+pipeline.shift #=> "A", "bold", "move", "westward", nil
+```
+
+Every part a splitter yields is policy-governed as it crosses into the next worker — under `:frozen`, each part arrives frozen downstream.
+
+## `trailing_worker`
+
+Returns an array of the last *n* values — useful for rolling averages. Nothing is returned until *n* values have accumulated; new values are unshifted into position zero.
+
+```ruby
+trailer = trailing_worker 4
+pipeline = source_worker(0..5) | trailer
+pipeline.shift #=> [3, 2, 1, 0], then [4, 3, 2, 1], then [5, 4, 3, 2], then nil
+```
+
+New in 0.6.0: the trailing worker **hands off a snapshot** (`trail.dup`) rather than its live closure array. It keeps mutating that array across calls, and a downstream `:frozen` intake would otherwise freeze the live array in place. This is the canonical example of the builder snapshot rule — see [[Coding-Idioms-Under-Frozen]].
+
+(Signature note: `trailing_worker(trail_length = 2)` takes the length positionally and no options hash.)
+
+## Raw `Shifty::Worker.new`
+
+When the DSL shapes don't fit, build a worker directly:
+
+```ruby
+worker = Shifty::Worker.new(
+  supply:   upstream,           # or wire later: worker.supply = upstream
+  policy:   :isolated,          # this worker's contract; validated eagerly
+  name:     "enricher",         # used in PolicyViolation / UnshareableValue messages
+  tags:     [:etl],             # also reported in diagnostics
+  criteria: ->(w) { ... },      # when falsy, the task is bypassed (value still policy-governed)
+  task:     some_callable       # or pass a block
+) { |value, supply, context| ... }
+```
+
+The task's arity matters:
+
+- **Arity 0** — a source; it cannot accept a supply (`supply=` raises). Use `handoff(value)` (which is `Fiber.yield`) to emit from inside loops.
+- **Arity 1+** — `|value|` receives the policy-governed intake value.
+- **Second argument** — a policy-governed supply proxy responding only to `#shift`, for tasks that pull additional values themselves (this is how filter/batch/trailing work). It is *not* the raw upstream worker.
+- **Third argument** — the worker's `context`, an `OpenStruct` by default or whatever you pass as `context:`; per-worker mutable state that survives across shifts (and survives a rescued `PolicyViolation`).
+
+A worker with no task gets a default pass-through task. `worker.effective_policy` reports the resolved policy (own declaration, else pipeline default, else global default).
+
+## Composition: `|`, `with_policy`, `freeze!`
+
+```ruby
+pipeline = source | filter | transform | sink   # tail-returned; call shift on it
+
+pipeline = (source | filter | transform | sink)
+  .with_policy(:frozen)   # pipeline default for workers with no declaration
+  .freeze!                # lock the topology; upstream walk from the tail
+```
+
+Both `with_policy` and `freeze!` walk **upstream** through the supply chain from their receiver and return it, so they chain — and both should be called on the pipeline's tail. `freeze!` locks topology only (supply wiring, Gang rosters); closure and context state stay mutable. Use `#freeze!`, never bare `#freeze`. Details in [[Handoff-Policies]].
+
+## `Shifty::Gang`
+
+A Gang wraps an ordered roster of workers so a whole chain acts like one worker: it has a `supply`, a `shift`, and composes with `|` like anything else.
+
+```ruby
+gang = Shifty::Gang[parser, enricher]          # or Gang.new([parser, enricher])
+pipeline = reader | gang | writer
+```
+
+Policy features:
+
+- **Construction fanout:** `Gang.new(workers, policy: :isolated)` sets the pipeline default on every roster member.
+- **`with_policy` fanout:** `gang.with_policy(:shared)` does the same, chainably.
+- **Append inheritance:** the gang persists its declared policy, so workers appended *after* the declaration inherit it too.
+- **Member contracts win:** a roster member's own `policy:` declaration beats the gang's, per the usual precedence.
+- **Chains walk through:** `(upstream | gang | tail).with_policy(:isolated)` reaches the gang's roster *and* workers upstream of it; `freeze!` walks the same path.
+- **Freezing:** a frozen gang still runs, but its roster membership is locked — `append` raises `FrozenError`.
+- **Criteria bypass is still governed:** when a gang's `criteria` bypasses its workers, the value crossing the gang boundary is still policy-governed at the entry worker.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,13 @@
+**[[Home]]**
+
+*Concepts*
+- [[Handoff-Policies]]
+- [[Coding-Idioms-Under-Frozen]]
+- [[Worker-Types]]
+
+*Doing things*
+- [[Migration-Guide-0.6]]
+- [[Testing-Workers]]
+
+*Reference*
+- [[Performance]]

--- a/lib/shifty/errors.rb
+++ b/lib/shifty/errors.rb
@@ -48,7 +48,8 @@ module Shifty
         Either make the task non-destructive — e.g. `map` instead of `map!`, \
         `value.with(...)`, `arr + [x]`, `hash.merge(...)` — or declare a different \
         policy on this worker: `policy: :isolated` (task works on a private scratch \
-        copy) or `policy: :shared` (raw reference; no protection).
+        copy) or `policy: :shared` (raw reference; no protection). \
+        More: https://github.com/joelhelbling/shifty/wiki/Handoff-Policies
       MSG
     end
 
@@ -113,7 +114,8 @@ module Shifty
         "that cannot cross the handoff boundary under the #{policy.inspect} policy: " \
         "it cannot be #{(policy == :isolated) ? "deep-copied" : "frozen"}. " \
         "Declare `policy: :shared` on this worker (raw pass-by-reference), " \
-        "or restructure the value."
+        "or restructure the value. " \
+        "More: https://github.com/joelhelbling/shifty/wiki/Handoff-Policies"
     end
   end
 end

--- a/lib/shifty/version.rb
+++ b/lib/shifty/version.rb
@@ -1,3 +1,3 @@
 module Shifty
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/lib/shifty/worker.rb
+++ b/lib/shifty/worker.rb
@@ -150,20 +150,22 @@ module Shifty
     #
     # Note that single-threading does NOT make the data flowing between workers
     # safe on its own: because each value passes through every worker before the
-    # next value begins, a worker that mutates a handed-off value can silently
+    # next value begins, a worker that mutates a handed-off value could silently
     # corrupt what downstream workers observe. That hazard is orthogonal to
-    # threading and is addressed separately by handoff immutability policies
-    # (see docs/planning/handoff-immutability-policies.md).
+    # threading and is governed by handoff immutability policies: values are
+    # deeply frozen at intake by default (:frozen), with :isolated and :shared
+    # opt-outs per worker/pipeline/global (see lib/shifty/policy.rb and the
+    # project wiki's Handoff-Policies page).
     #
     # ### Alternatives (Threads/Ractors)
     # Threads and Ractors are not used for parallelism *yet*. Shifty's current
     # goal is an easy-to-use framework for sequential data pipelines, and a
     # single-threaded Fiber model serves that directly without the overhead of
     # mutexes (Threads) or the sharing restrictions of Ractors. This is a
-    # scoping decision, not a rejection: the planned move to deeply frozen,
-    # shareable handoff values is deliberately Ractor-compatible and lays the
-    # groundwork for a future Ractor-backed worker type. (Fibers cannot cross
-    # Ractor boundaries, so such a worker would be a distinct type, not a
+    # scoping decision, not a rejection: the default :frozen policy's deeply
+    # frozen, shareable handoff values are deliberately Ractor-compatible and
+    # lay the groundwork for a future Ractor-backed worker type. (Fibers cannot
+    # cross Ractor boundaries, so such a worker would be a distinct type, not a
     # retrofit of this one.)
     #
     # ### Thread Safety


### PR DESCRIPTION
Part 4 of 4, stacked on #29. Implements Phase 4 of [the plan](docs/planning/feature-implementation-plan.md) — the release itself.

## What's here

- **Version 0.6.0** + a new `CHANGELOG.md` covering the breaking changes (frozen-by-default handoffs, unshareable-value rejection, supply proxy, Ruby ≥ 3.2 floor), the `:hardened` deprecation (removed at 1.0.0), and everything added across Phases 1–3.
- **README**: new "Handoff Policies" section (rationale, comparison table, declaration levels, wiki links); the `side_worker` `:hardened` walkthrough rewritten to policy semantics; concurrency-model text updated from "planned" to shipped (closing the PR #26 forward-references); stale CodeClimate badges removed; Roadmap filled.
- **`docs/wiki/` — seven wiki pages** (Home, Handoff-Policies, Coding-Idioms-Under-Frozen, Migration-Guide-0.6, Testing-Workers, Worker-Types, Performance), drafted for review here and pushed to the GitHub wiki repo after merge.
- **Doc reconciliation**: `docs/use_cases.md`, `lib/shifty/worker.rb` comments, `docs/shifty/worker.md` (dropped the `task=` examples — no such accessor exists), and a post-implementation corrections header on the design doc (Marshal for `:isolated`; proactive IO detection because `make_shareable` silently freezes live IO; `PolicyConflict` dropped).

## Release checklist

- [x] All four phases merged in sequence (#27 → #28 → #29 → this)
- [x] 166 examples, 0 failures; standardrb clean; CI matrix 3.2/3.3/3.4
- [x] `gem build shifty.gemspec` → **`shifty-0.6.0.gem`** (built locally; rebuild after merge with the same command)
- [ ] Joel publishes the gem (2FA)
- [ ] Push `docs/wiki/*.md` to `joelhelbling/shifty.wiki.git` (I'll do this after merge; requires the wiki to be enabled on the repo)