### PR TITLE
Gate deprecation warnings behind Warning[:deprecated]; raise WorkerError when unready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Changes
+
+- **Deprecation warnings now use Ruby's `:deprecated` warning category.**
+  All of Shifty's deprecation warnings (the `supply` → `supplier` rename,
+  policy `:hardened`, side_worker's `mode:` option) are emitted via
+  `Kernel#warn(..., category: :deprecated)`, so they are silent by default
+  and controlled the standard way: `Warning[:deprecated] = true`,
+  `-W:deprecated`, or `-w`.
+- **An unready worker now raises `Shifty::WorkerError`** ("...has no
+  supplier") instead of a bare `RuntimeError`, matching the error raised
+  when assigning a supplier to a source worker.
+
 ### Deprecations
 
 - **`supply` is renamed to `supplier`** on `Worker` and `Gang` (issue #22):

--- a/lib/shifty/configuration.rb
+++ b/lib/shifty/configuration.rb
@@ -24,9 +24,12 @@ module Shifty
       @config = Configuration.new
     end
 
+    # Emitted under the :deprecated category so users control visibility
+    # the standard way (Warning[:deprecated] = true, -W:deprecated, or -w).
     def deprecation_warning(old_name, new_name)
       warn "[shifty] #{old_name} is deprecated and will be " \
-           "removed in 1.0.0; use #{new_name} instead."
+           "removed in 1.0.0; use #{new_name} instead.",
+        category: :deprecated
     end
   end
 end

--- a/lib/shifty/dsl.rb
+++ b/lib/shifty/dsl.rb
@@ -147,12 +147,12 @@ module Shifty
       return unless options.key?(:mode)
       mode = options.delete(:mode)
       if mode == :hardened
-        warn "[shifty] side_worker mode: :hardened is deprecated and will be " \
-             "removed in 1.0.0; use policy: :isolated instead."
+        Shifty.deprecation_warning("side_worker mode: :hardened", "policy: :isolated")
         options[:policy] ||= :isolated
       else
         warn "[shifty] side_worker's mode: option is deprecated and ignored " \
-             "(received mode: #{mode.inspect}); declare a policy: instead."
+             "(received mode: #{mode.inspect}); declare a policy: instead.",
+          category: :deprecated
       end
     end
 

--- a/lib/shifty/policy.rb
+++ b/lib/shifty/policy.rb
@@ -88,8 +88,7 @@ module Shifty
       def canonical(name)
         if ALIASES.key?(name)
           replacement = ALIASES[name]
-          warn "[shifty] policy :#{name} is deprecated and will be " \
-               "removed in 1.0.0; use :#{replacement} instead."
+          Shifty.deprecation_warning("policy :#{name}", ":#{replacement}")
           replacement
         else
           name

--- a/lib/shifty/worker.rb
+++ b/lib/shifty/worker.rb
@@ -96,7 +96,7 @@ module Shifty
       @task ||= default_task
 
       unless ready_to_work?
-        raise "This worker's task expects to receive a value from a supplier, but has no supplier."
+        raise WorkerError.new("This worker's task expects to receive a value from a supplier, but has no supplier.")
       end
     end
 

--- a/spec/shifty/handoff_policy_spec.rb
+++ b/spec/shifty/handoff_policy_spec.rb
@@ -290,7 +290,9 @@ module Shifty
       context "side_worker mode: :hardened behaves as :isolated and warns" do
         Given(:warning) do
           capture_stderr do
-            @worker = side_worker(mode: :hardened, &unsafe_task)
+            with_deprecation_warnings do
+              @worker = side_worker(mode: :hardened, &unsafe_task)
+            end
           end
         end
         Given(:pipeline) { source | @worker }
@@ -303,7 +305,9 @@ module Shifty
       context "Worker policy: :hardened maps to :isolated and warns" do
         Given(:warning) do
           capture_stderr do
-            @worker = Worker.new(policy: :hardened) { |v| v }
+            with_deprecation_warnings do
+              @worker = Worker.new(policy: :hardened) { |v| v }
+            end
           end
         end
 
@@ -405,7 +409,9 @@ module Shifty
     describe "deprecated mode: values other than :hardened warn and are ignored" do
       Given(:warning) do
         capture_stderr do
-          @worker = side_worker(mode: :normal) { |v| v }
+          with_deprecation_warnings do
+            @worker = side_worker(mode: :normal) { |v| v }
+          end
         end
       end
 

--- a/spec/shifty/policy_spec.rb
+++ b/spec/shifty/policy_spec.rb
@@ -37,7 +37,7 @@ module Shifty
 
       context "maps deprecated :hardened to :isolated with a warning" do
         Given(:warning) do
-          capture_stderr { @resolved = Policy.resolve(:hardened) }
+          capture_stderr { with_deprecation_warnings { @resolved = Policy.resolve(:hardened) } }
         end
         Then { expect(warning).to match(/:hardened is deprecated.*:isolated/m) }
         And { expect(warning).to match(/removed in 1\.0\.0/) }

--- a/spec/shifty/supplier_spec.rb
+++ b/spec/shifty/supplier_spec.rb
@@ -21,24 +21,34 @@ module Shifty
       end
 
       describe "unready worker error message names the supplier" do
-        Then { expect { relay.shift }.to raise_error(/has no supplier/) }
+        Then { expect { relay.shift }.to raise_error(WorkerError, /has no supplier/) }
+      end
+
+      describe "deprecation warnings honor Warning[:deprecated]" do
+        When(:warning) do
+          capture_stderr do
+            with_deprecation_warnings(enabled: false) { relay.supply = source }
+          end
+        end
+        Then { warning.empty? }
+        And  { relay.supplier == source }
       end
 
       describe "deprecated #supply reader" do
         Given { relay.supplier = source }
-        When(:warning) { capture_stderr { @result = relay.supply } }
+        When(:warning) { capture_stderr { with_deprecation_warnings { @result = relay.supply } } }
         Then { @result == source }
         And  { warning.match?(/\[shifty\].*#supply is deprecated.*#supplier/m) }
       end
 
       describe "deprecated #supply= writer" do
-        When(:warning) { capture_stderr { relay.supply = source } }
+        When(:warning) { capture_stderr { with_deprecation_warnings { relay.supply = source } } }
         Then { relay.supplier == source }
         And  { warning.match?(/\[shifty\].*#supply= is deprecated.*#supplier=/m) }
       end
 
       describe "deprecated supply: constructor option" do
-        When(:warning) { capture_stderr { @worker = Worker.new(supply: source) { |value| value } } }
+        When(:warning) { capture_stderr { with_deprecation_warnings { @worker = Worker.new(supply: source) { |value| value } } } }
         Then { @worker.supplier == source }
         And  { warning.match?(/\[shifty\].*supply:.*deprecated.*supplier:/m) }
       end
@@ -55,13 +65,13 @@ module Shifty
 
       describe "deprecated #supply reader" do
         Given { gang.supplier = source }
-        When(:warning) { capture_stderr { @result = gang.supply } }
+        When(:warning) { capture_stderr { with_deprecation_warnings { @result = gang.supply } } }
         Then { @result == source }
         And  { warning.match?(/\[shifty\].*#supply is deprecated.*#supplier/m) }
       end
 
       describe "deprecated #supply= writer" do
-        When(:warning) { capture_stderr { gang.supply = source } }
+        When(:warning) { capture_stderr { with_deprecation_warnings { gang.supply = source } } }
         Then { gang.supplier == source }
         And  { warning.match?(/\[shifty\].*#supply= is deprecated.*#supplier=/m) }
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,16 @@ module StderrCapture
   ensure
     $stderr = original
   end
+
+  # Shifty's deprecation warnings are emitted under Ruby's :deprecated
+  # warning category, which is disabled by default; toggle it to observe.
+  def with_deprecation_warnings(enabled: true)
+    original = Warning[:deprecated]
+    Warning[:deprecated] = enabled
+    yield
+  ensure
+    Warning[:deprecated] = original
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary

Two pre-0.7.0 polish items:

**Deprecation warnings now use Ruby's `:deprecated` category.** All of Shifty's deprecation warnings — the `supply` → `supplier` rename, policy `:hardened`, and `side_worker`'s `mode:` option — are emitted via `warn(..., category: :deprecated)` through a single `Shifty.deprecation_warning` seam. They are silent by default and controlled the standard way (`Warning[:deprecated] = true`, `-W:deprecated`, or `-w`), consistent with how `deprecate_constant` already gates `Policy::Supply`.

**An unready worker raises `Shifty::WorkerError`.** `ensure_ready_to_work!` previously raised a bare `RuntimeError`; it now raises `WorkerError` ("...has no supplier"), matching the guard in `Worker#supplier=`, so both wiring errors are rescuable under one class.

Specs gained a `with_deprecation_warnings` helper that toggles `Warning[:deprecated]` around stderr captures, plus a test that warnings stay silent when the category is disabled.

## Test plan
- New tests written first and watched fail (WorkerError class, category suppression)
- Full suite: 178 examples, 0 failures; `standardrb` clean
- Verified end-to-end: default run is silent, `-W:deprecated` surfaces the warning, unready shift raises rescuable `WorkerError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)